### PR TITLE
Updating default branch to 'main'.

### DIFF
--- a/.github/workflows/corejs-analyze.yml
+++ b/.github/workflows/corejs-analyze.yml
@@ -2,9 +2,9 @@ name: Analyze packages/corejs
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   analyze:

--- a/.github/workflows/react-native-analyze.yml
+++ b/.github/workflows/react-native-analyze.yml
@@ -2,9 +2,9 @@ name: Analyze packages/react-native
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   analyze:

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -2,9 +2,9 @@ name: Deploy documentation
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   checks:

--- a/packages/corejs/README.md
+++ b/packages/corejs/README.md
@@ -37,4 +37,4 @@ function App() {
 This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more info.
 
 ----
-![Monk banner](https://raw.githubusercontent.com/monkvision/monkjs/master/assets/banner.webp)
+![Monk banner](https://raw.githubusercontent.com/monkvision/monkjs/main/assets/banner.webp)

--- a/packages/cra-template/README.md
+++ b/packages/cra-template/README.md
@@ -5,4 +5,4 @@
 yarn create react-app <project-name> --template @monkvision/cra-template
 ```
 ---
-![Monk banner](https://raw.githubusercontent.com/monkvision/monkjs/master/assets/banner.webp)
+![Monk banner](https://raw.githubusercontent.com/monkvision/monkjs/main/assets/banner.webp)

--- a/packages/cra-template/template/CHECKME.md
+++ b/packages/cra-template/template/CHECKME.md
@@ -10,7 +10,7 @@ Here you can find popular alternatives to
 * [ ] Configure tokens and authentication on your repository if needed
 * [ ] Clone you repository with CLI or UI
 * [ ] Build initial sources
-* [ ] Git commit with message `commit -m "Build initial sources"` and push to remote:master
+* [ ] Git commit with message `commit -m "Build initial sources"` and push to remote:main
 
 ## Establishing rules and tools
 * [ ] Choose a git flow

--- a/packages/cra-template/template/README.md
+++ b/packages/cra-template/template/README.md
@@ -90,7 +90,7 @@ cp .env .env.local
 
 **[Based on our versioning rules.](https://www.notion.so/Versioning-2dc3113c8e6340f6bd45bdd97f303602)**
 
-- Branch `master` is the more advanced development version and is protected
+- Branch `main` is the more advanced development version and is protected
 - Branch `live` is for production and is protected
 - Trust our assistant `Futura` via [workflows and actions](https://docs.github.com/en/actions)
 - Rebase only if necessary otherwise keep the history of your work

--- a/packages/react-native-views/README.md
+++ b/packages/react-native-views/README.md
@@ -31,4 +31,4 @@ Module content:
 This project is licensed under the BSD-3-Clause-Clear license. See the [LICENSE](LICENSE) file for more info.
 
 ----
-![Monk banner](https://raw.githubusercontent.com/monkvision/monkjs/master/assets/banner.webp)
+![Monk banner](https://raw.githubusercontent.com/monkvision/monkjs/main/assets/banner.webp)

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -33,4 +33,4 @@ Module content:
 This project is licensed under the BSD-3-Clause-Clear license. See the [LICENSE](LICENSE) file for more info.
 
 ----
-![Monk banner](https://raw.githubusercontent.com/monkvision/monkjs/master/assets/banner.webp)
+![Monk banner](https://raw.githubusercontent.com/monkvision/monkjs/main/assets/banner.webp)

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -25,7 +25,7 @@ Install from `yarn`
 yarn add @monkvision/corejs @reduxjs/toolkit
 ```
 
-⛓️ Peer dependencies in [`package.json`](https://github.com/monkvision/monkjs/tree/master/packages/corejs/package.json):
+⛓️ Peer dependencies in [`package.json`](https://github.com/monkvision/monkjs/tree/main/packages/corejs/package.json):
  ``` json
 "@reduxjs/toolkit": "*"
  ```
@@ -44,7 +44,7 @@ Install from `yarn`
 yarn add @monkvision/react-native prop-types react react-native react-native-svg
 ```
 
-⛓️ Peer dependencies in [`package.json`](https://github.com/monkvision/monkjs/tree/master/packages/react-native/package.json):
+⛓️ Peer dependencies in [`package.json`](https://github.com/monkvision/monkjs/tree/main/packages/react-native/package.json):
  ``` json
 "prop-types": "*",
 "react": "*",
@@ -67,7 +67,7 @@ Install from `yarn`
 yarn add @monkvision/react-native-views @monkvision/corejs @monkvision/react-native
 ```
 
-⛓️ Peer dependencies in [`package.json`](https://github.com/monkvision/monkjs/tree/master/packages/react-native-views/package.json):
+⛓️ Peer dependencies in [`package.json`](https://github.com/monkvision/monkjs/tree/main/packages/react-native-views/package.json):
  ``` json
 "@monkvision/corejs": "*",
 "@monkvision/react-native": "*",

--- a/website/docs/js/guides/picturing.md
+++ b/website/docs/js/guides/picturing.md
@@ -10,7 +10,7 @@ The Camera view takes on a more complete state with **Sights**. We recommend usi
 yarn add @monkvision/react-native-views @monkvision/corejs @monkvision/react-native
 ```
 
-⛓️ Peer deps in [`@monkvision/react-native-views/package.json`](https://github.com/monkvision/monkjs/tree/master/packages/react-native-views/package.json)
+⛓️ Peer deps in [`@monkvision/react-native-views/package.json`](https://github.com/monkvision/monkjs/tree/main/packages/react-native-views/package.json)
 
 ``` javascript
 import { CameraView } from `@monkvision/react-native-views`


### PR DESCRIPTION
This includes all the mentions of the branch that I'm aware of, that is: in the github workflows and the documentation.

The change is motivated by the now github default to move away from slavery related terms: https://github.com/github/renaming