### PR TITLE
Feature/fe 223/intergration issues in advices

### DIFF
--- a/packages/react-native-views/src/components/TutorialView/index.jsx
+++ b/packages/react-native-views/src/components/TutorialView/index.jsx
@@ -31,6 +31,7 @@ const styles = StyleSheet.create({
   advices: {
     width: '100%',
     height: '100%',
+    zIndex: 10,
     borderRadius: 40,
     overflow: 'hidden',
     maxWidth: 500,
@@ -52,6 +53,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     flexWrap: 'wrap',
+    zIndex: 0,
   },
   cta: { width: 140, margin: utils.styles.spacing(1) },
   text: { textAlign: 'center', margin: utils.styles.spacing(2) },
@@ -130,7 +132,7 @@ function TutorialView({ nbOfInsidePics, nbOfOutsidePics, onStart, theme }) {
             </Text>
 
             {/* toggle explanation dialog */}
-            <TouchableOpacity onPress={onOpenExplanation} style={{ height: 14 }}>
+            <TouchableOpacity onPress={onOpenExplanation} style={{ height: 16 }}>
               <Text style={{ color: colors.primary }}> See more.</Text>
             </TouchableOpacity>
           </Text>

--- a/packages/react-native/src/components/PicturesScrollPreview/styles.js
+++ b/packages/react-native/src/components/PicturesScrollPreview/styles.js
@@ -14,7 +14,6 @@ const styles = StyleSheet.create({
   scrollContainer: {
     flex: 1,
     overflow: 'visible',
-    paddingTop: 32,
     padding: 8,
   },
   gradient: {


### PR DESCRIPTION
Fixed getting started button overlaps the advice modal.
Couldn't find the crop error of the advice modal.