### PR TITLE
Creating one global hook, for upload images to a specific task in an …

### DIFF
--- a/src/hooks/useUpload/index.js
+++ b/src/hooks/useUpload/index.js
@@ -3,17 +3,15 @@ import { useDispatch } from 'react-redux';
 
 import { addOneImageToInspection, config } from '@monkvision/corejs';
 import { Platform } from 'react-native';
+import { noop } from 'lodash';
 
-export default ({ inspectionId, setPictures }) => {
+export default ({ onLoading = noop, onSuccess = noop, onError = noop, inspectionId, taskName = 'damage_detection' }) => {
   const dispatch = useDispatch();
 
-  const handleUploadPicture = useCallback(async (picture, id) => {
+  const handleUploadPicture = useCallback(async (uri, id) => {
     if (!inspectionId) { return; }
 
-    setPictures((prev) => prev.map((image) => {
-      if (image.id === id) { return { ...image, isLoading: true }; }
-      return image;
-    }));
+    onLoading(id);
 
     const filename = `${id}-${inspectionId}.jpg`;
     const multiPartKeys = { image: 'image', json: 'json', filename, type: 'image/jpg' };
@@ -22,50 +20,28 @@ export default ({ inspectionId, setPictures }) => {
     const baseParams = { inspectionId, headers };
 
     const acquisition = { strategy: 'upload_multipart_form_keys', file_key: multiPartKeys.image };
-    const json = JSON.stringify({ acquisition, tasks: ['damage_detection'] });
+    const json = JSON.stringify({ acquisition, tasks: [taskName] });
 
     const data = new FormData();
     data.append(multiPartKeys.json, json);
 
     if (Platform.OS === 'web') {
-      const response = await fetch(picture);
+      const response = await fetch(uri);
       const blob = await response.blob();
       const file = await new File([blob], multiPartKeys.filename, { type: multiPartKeys.type });
       data.append(multiPartKeys.image, file);
     } else {
       data.append('image', {
-        uri: picture,
+        uri,
         name: multiPartKeys.filename,
         type: multiPartKeys.type,
       });
     }
 
     dispatch(addOneImageToInspection({ ...baseParams, data })).unwrap()
-      .then(() => {
-        setPictures((prev) => prev.map((image) => {
-          if (image.id === id) {
-            return {
-              ...image,
-              isUploaded: true,
-              isLoading: false,
-              isFailed: false };
-          }
-          return image;
-        }));
-      })
-      .catch(() => {
-        setPictures((prev) => prev.map((image) => {
-          if (image.id === id) {
-            return {
-              ...image,
-              isUploaded: true,
-              isFailed: true,
-              isLoading: false };
-          }
-          return image;
-        }));
-      });
-  }, [dispatch, inspectionId, setPictures]);
+      .then((res) => onSuccess(id, res))
+      .catch((err) => onError(id, err));
+  }, [dispatch, inspectionId, onError, onLoading, onSuccess, taskName]);
 
   return handleUploadPicture;
 };

--- a/src/screens/InspectionImport/hooks/useImport/index.js
+++ b/src/screens/InspectionImport/hooks/useImport/index.js
@@ -4,7 +4,7 @@ import { Dimensions, Platform } from 'react-native';
 
 import { utils } from '@monkvision/react-native';
 
-import useUpload from '../useUpload';
+import useUpload from 'hooks/useUpload';
 
 const { width, height } = Dimensions.get('window');
 export const initialPictureData = { isLoading: false, isFailed: false, isUploaded: false, id: '', label: '', uri: null };
@@ -12,7 +12,23 @@ export const initialPictureData = { isLoading: false, isFailed: false, isUploade
 export default ({ pictures, setPictures, inspectionId }) => {
   const [accessGranted, setAccess] = useState(false);
 
-  const handleUploadPicture = useUpload({ inspectionId, setPictures });
+  const onLoading = useCallback((id) => setPictures(
+    (prev) => prev.map((image) => (image.id === id ? { ...image, isLoading: true } : image)),
+  ), [setPictures]);
+
+  const onSuccess = useCallback((id) => setPictures((prev) => prev.map((image) => (image.id === id
+    ? { ...image, isUploaded: true, isLoading: false, isFailed: false } : image))), [setPictures]);
+
+  const onError = useCallback((id) => setPictures((prev) => prev.map((image) => (image.id === id ? {
+    ...image, isUploaded: false, isFailed: true, isLoading: false } : image))),
+  [setPictures]);
+
+  const handleUploadPicture = useUpload({
+    inspectionId,
+    onSuccess,
+    onLoading,
+    onError,
+  });
 
   // request media library permission
   const handleRequestMediaLibraryAccess = useCallback(async () => {


### PR DESCRIPTION
ALL CONTRIBUTIONS WILL BE REVIEWED BY AT LEAST ONE OF OUR FRONTEND TEAM MEMBERS.

<!--- Before all please request a review from your team leader -->
<!--- and members who might be interested in this PR  -->

## Technical description
<!--- Describe your changes technically in detail -->

Created a new hook useUpload, that holds all the logic of uploading images to an inspection, and implemented in `createInspection` and `importInspection` screens.

The hook takes an object of 5 properties as a param:
- inspectionId `string`, required.
- taskName `string` default value `damage_detection`.
- onSuccess `(inspectionId, response) => void`.
- onError `(inspectionId, error) => void`.
- onLoading `(inspectionId) => void`.

## Related to
<!--- If the your changes are related to an open PR, issue or Jira ticket -->
<!--- please link it with it's title. -->

This PR is related to any issue.

## About Tests

<!--- Please provide all devices used while testing -->
Tested on the following devices

- Web chrome 
- iPhone 8

<!--- Steps in details to reproduce the solved issue usecases and to test the solution -->
Steps to reproduce

1. Create inspection from camera
2. Create inspection from camera roll

<!--- Include details of your testing environment, to see how your change -->
<!--- affects other areas of the code... -->

## Screenshots (optional):

No screenshots.
*This Pull Request template has been written and generated by Monk JS repository.*

