### PR TITLE
Fix Get Signature format error

### DIFF
--- a/packages/corejs/src/users/usersApi.js
+++ b/packages/corejs/src/users/usersApi.js
@@ -28,16 +28,19 @@ export function updateOne({ id, accessToken, data, ...customReqConfig }) {
   });
 }
 
-export function getSignature({ id, params, ...customReqConfig }) {
+export async function getSignature({ id, params, ...customReqConfig }) {
   const http = axios.create(config.axiosConfig);
-
-  return http.request({
-    method: 'get',
-    url: `users/${id}/signatures`,
-    params,
-    responseType: 'blob',
-    ...customReqConfig,
-  });
+  const { data } = await http.get(`users/${id}/signatures`);
+  if (data.has_signature) {
+    return http.request({
+      method: 'get',
+      url: `users/${id}/signatures`,
+      params,
+      responseType: 'blob',
+      ...customReqConfig,
+    });
+  }
+  return Promise.reject(new Error('Don\'t have signature yet'));
 }
 
 export function setSignature({ id, data, ...customReqConfig }) {


### PR DESCRIPTION
There is an error whenever the user loads the profile page. I think it comes from the fact that if the user does not have a signature yet, then the api send a json response like that:
```json
{
   "has_signature": false
}
```
But at first I did not checked that and take the response as a Blob without taking in consideration that the response could be a json even if the param query `return_image` was at `true`.

The problem now is that I don't know how to handle the case where it fails, so I temporarily put a `Promise.reject()`.