### PR TITLE
Fix manual damage image not displaying

### DIFF
--- a/packages/react-native/src/components/DamageHighlight/index.js
+++ b/packages/react-native/src/components/DamageHighlight/index.js
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Dimensions, Platform, View } from 'react-native';
+import { Dimensions, Platform, View, Image as Img } from 'react-native';
 import { ClipPath, Defs, G, Image, Polygon, Svg } from 'react-native-svg';
 import PropTypes from 'prop-types';
 import isEmpty from 'lodash.isempty';
@@ -71,8 +71,10 @@ DamageImage.defaultProps = {
 };
 
 export default function DamageHighlight({ image, polygons }) {
-  if (!image || isEmpty(polygons)) {
+  if (!image) {
     return <View />;
+  } if (isEmpty(polygons)) {
+    return <Img style={{ height, width }} source={image.source} />;
   }
 
   return (


### PR DESCRIPTION
ALL CONTRIBUTIONS WILL BE REVIEWED BY AT LEAST ONE OF OUR FRONTEND TEAM MEMBERS.

<!--- Before all please request a review from your team leader -->
<!--- and members who might be interested in this PR  -->

<!--- in case this is a new idea proposal please use the NEW_IDEA_PROPOSAL template by adding -->
<!--- ?template=NEW_IDEA_PROPOSAL.md to this page url -->

## Technical description
Manual damage image not displaying in DamageRead screen

## Related to
Changes on the DamageHighlight component

Tested on the following devices

- Web
- Emulator iOS 11

*This Pull Request template has been written and generated by Monk JS repository.*

