### PR TITLE
Fixed the damage form row trim bug(on android)

### DIFF
--- a/packages/react-native-views/src/components/CreateDamageForm/DamageRow/index.js
+++ b/packages/react-native-views/src/components/CreateDamageForm/DamageRow/index.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View, Text, StyleSheet } from 'react-native';
 import { IconButton, DataTable } from 'react-native-paper';
 import { startCase } from 'lodash';
+import { useMediaQuery } from 'react-responsive';
 
 const styles = StyleSheet.create({
   cell: {
@@ -18,21 +19,25 @@ const styles = StyleSheet.create({
   title: { maxWidth: 100 },
 });
 
-const MAX_POSSIBLE_LENGTH = 25;
-const handleValueWidth = (value) => {
-  if (value?.length > MAX_POSSIBLE_LENGTH) {
-    return `${startCase(value?.substring(0, 20))}...`;
-  }
-  return startCase(value);
-};
+// width < 350 ? MAX_POSSIBLE_LENGTH : Infinity
 
 export default function DamageRow({ value, title, ...rest }) {
+  const isMobile = useMediaQuery({ query: '(max-device-width: 350px)' });
+
+  const handleValueWidth = useMemo(() => {
+    const MAX_POSSIBLE_LENGTH = isMobile ? 25 : Infinity;
+    if (value?.length > MAX_POSSIBLE_LENGTH) {
+      return `${startCase(value?.substring(0, 20))}...`;
+    }
+    return startCase(value);
+  }, [value, isMobile]);
+
   return (
     <DataTable.Row {...rest}>
       <DataTable.Cell style={styles.title}>{title}</DataTable.Cell>
       <DataTable.Cell style={styles.alignLeft}>
         <View style={styles.cell}>
-          <Text>{handleValueWidth(value) || 'Not given'}</Text>
+          <Text>{handleValueWidth || 'Not given'}</Text>
           <IconButton icon="pencil" disabled />
         </View>
       </DataTable.Cell>

--- a/packages/react-native-views/src/components/CreateDamageForm/DamageRow/index.js
+++ b/packages/react-native-views/src/components/CreateDamageForm/DamageRow/index.js
@@ -12,16 +12,27 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     flexDirection: 'row',
     paddingTop: 5,
+    flexGrow: 1,
   },
   alignLeft: { justifyContent: 'flex-end' },
+  title: { maxWidth: 100 },
 });
+
+const MAX_POSSIBLE_LENGTH = 25;
+const handleValueWidth = (value) => {
+  if (value?.length > MAX_POSSIBLE_LENGTH) {
+    return `${startCase(value?.substring(0, 20))}...`;
+  }
+  return startCase(value);
+};
+
 export default function DamageRow({ value, title, ...rest }) {
   return (
     <DataTable.Row {...rest}>
-      <DataTable.Cell>{title}</DataTable.Cell>
+      <DataTable.Cell style={styles.title}>{title}</DataTable.Cell>
       <DataTable.Cell style={styles.alignLeft}>
         <View style={styles.cell}>
-          <Text>{startCase(value) || 'Not given'}</Text>
+          <Text>{handleValueWidth(value) || 'Not given'}</Text>
           <IconButton icon="pencil" disabled />
         </View>
       </DataTable.Cell>

--- a/packages/react-native-views/src/components/CreateDamageForm/useDamagesForm.js
+++ b/packages/react-native-views/src/components/CreateDamageForm/useDamagesForm.js
@@ -19,7 +19,6 @@ export default function useDamagesForm({ onChangeCurrentDamage, setDamagePicture
   }, [openSelectDialog]);
 
   const handleDismissSelectDialog = useCallback(() => {
-    setSelectField(null);
     closeSelectDialog();
   }, [closeSelectDialog]);
 


### PR DESCRIPTION
ALL CONTRIBUTIONS WILL BE REVIEWED BY AT LEAST ONE OF OUR FRONTEND TEAM MEMBERS.

<!--- Before all please request a review from your team leader -->
<!--- and members who might be interested in this PR  -->

<!--- in case this is a new idea proposal please use the NEW_IDEA_PROPOSAL template by adding -->
<!--- ?template=NEW_IDEA_PROPOSAL.md to this page url -->

## Technical description
<!--- Describe your changes technically in detail -->
Fixed form row part_type and damage_type value (was getting overflow) on android and small screens.


## About Tests

<!--- Please provide all devices used while testing -->
Tested on the following devices

- Android pixel 4 XL
- Web browser

<!--- Steps in details to reproduce the solved issue usecases and to test the solution -->
Steps to reproduce

1. Open the create damage form on Android
2. Choose a long value of Damage Type or Part Type

<!--- Include details of your testing environment, to see how your change -->
<!--- affects other areas of the code... -->

## Screenshots (optional):

Before
![image](https://user-images.githubusercontent.com/50136109/148249900-b316ed61-3fc8-4aa7-a07f-5a017b937258.png)

After
![image](https://user-images.githubusercontent.com/50136109/148249840-712fa83d-a5f3-4b6c-9d31-9d49af4f314f.png)

*This Pull Request template has been written and generated by Monk JS repository.*

