### PR TITLE
Adding text for empty inspection, and disabling damages button when w…

### DIFF
--- a/packages/react-native-views/src/components/Damages/index.js
+++ b/packages/react-native-views/src/components/Damages/index.js
@@ -1,7 +1,8 @@
 /* eslint-disable react/prop-types */
 import React, { useImperativeHandle, forwardRef } from 'react';
-import { View } from 'react-native';
+import { Text, View } from 'react-native';
 import { ActivityIndicatorView } from '@monkvision/react-native-views';
+import { utils } from '@monkvision/react-native';
 import { Provider as PaperProvider } from 'react-native-paper';
 import useComputedParts from '../../hooks/useComputedParts';
 import usePartDamages from '../../hooks/usePartDamages';
@@ -41,7 +42,13 @@ function Damages({
     validate: handleOpenDialog,
   }));
 
-  if (partsWithDamages.length === 0) { return null; }
+  if (!partsWithDamages?.length) {
+    return (
+      <View style={utils.styles.flex}>
+        <Text>This inspection has no damage.</Text>
+      </View>
+    );
+  }
 
   return (
     <View style={styles.root}>

--- a/src/screens/Damages/index.js
+++ b/src/screens/Damages/index.js
@@ -30,7 +30,6 @@ import useDamages from './useDamages';
 
 const styles = StyleSheet.create({
   root: {
-    // display: 'flex',
     width: '100%',
     height: '100%',
     flex: 1,

--- a/src/screens/InspectionRead/index.js
+++ b/src/screens/InspectionRead/index.js
@@ -285,6 +285,7 @@ export default () => {
                 onPress={handleShowDamages}
                 color={theme.colors.warning}
                 style={{ marginRight: spacing(1) }}
+                disabled={!partsWithDamages?.length}
               >
                 {(isEmpty(inspection.damages)) ? 'No damage' : (
                   `${inspection.damages.length} damage${inspection.damages.length > 1 ? 's' : ''}`


### PR DESCRIPTION
…e have no damages

ALL CONTRIBUTIONS WILL BE REVIEWED BY AT LEAST ONE OF OUR FRONTEND TEAM MEMBERS.

<!--- Before all please request a review from your team leader -->
<!--- and members who might be interested in this PR  -->

<!--- in case this is a new idea proposal please use the NEW_IDEA_PROPOSAL template by adding -->
<!--- ?template=NEW_IDEA_PROPOSAL.md to this page url -->

## Technical description
<!--- Describe your changes technically in detail -->

## Related to
<!--- If the your changes are related to an open PR, issue or Jira ticket -->
<!--- please link it with it's title. -->

This PR is related to [Q/A Fix blank damages screen when all damages are deleted](https://monkvision.atlassian.net/browse/FE-272)

## About Tests

<!--- Please provide all devices used while testing -->
Tested on the following devices

- Web browser chrome
- iOS

<!--- Steps in details to reproduce the solved issue usecases and to test the solution -->
Steps to reproduce

1. Delete all damages from an inspection
2. Try to hit the damage button

## Screenshots (optional):

No screenshots.
*This Pull Request template has been written and generated by Monk JS repository.*

