### PR TITLE
Get rid of the annoying useless warnings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,9 @@ import { Provider as PaperProvider, DefaultTheme } from 'react-native-paper';
 import Navigation from 'Navigation';
 
 import 'config/corejs';
+import ignoreLogs from 'config/ignoreLogs';
+
+ignoreLogs(['EventEmitter.addListener', 'Require cycle'], 'error');
 
 const theme = {
   ...DefaultTheme,

--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ import Navigation from 'Navigation';
 import 'config/corejs';
 import ignoreLogs from 'config/ignoreLogs';
 
-ignoreLogs(['EventEmitter.addListener', 'Require cycle'], 'error');
+ignoreLogs(['EventEmitter.addListener'], 'error');
 
 const theme = {
   ...DefaultTheme,

--- a/src/config/ignoreLogs.js
+++ b/src/config/ignoreLogs.js
@@ -1,0 +1,13 @@
+/* eslint-disable no-console */
+import { Platform, LogBox } from 'react-native';
+
+export default function ignoreLogs(supressedWarnings, severity = 'error') {
+  if (Platform.OS !== 'web') { LogBox.ignoreLogs(supressedWarnings); return; }
+
+  const backup = console[severity];
+  console[severity] = function filterWarnings(msg) {
+    if (!supressedWarnings.some((entry) => msg.includes(entry))) {
+      backup.apply(console);
+    }
+  };
+}


### PR DESCRIPTION
ALL CONTRIBUTIONS WILL BE REVIEWED BY AT LEAST ONE OF OUR FRONTEND TEAM MEMBERS.

<!--- Before all please request a review from your team leader -->
<!--- and members who might be interested in this PR -->

## Overall
<!--- Please provide an overall description of your proposal -->
<!--- How much days have you spent on this proposal? -->
<!--- What problem does your proposal solve? -->
Sometimes we get some console errors/warnings that we can't fix as they are coming from a package somehow, e,g **react-navigation** or **react-native-paper** are throwing `EventEmitter.addListener`.

## Technical description
<!--- Describe your changes technically in detail -->
Added a function config which will remove all the given errors/warnings as param, from the console one web, and will remove the also the annoying ones from the native `LogBox`.

*This Pull Request template has been written and generated by Monk JS repository.*

