### PR TITLE
Fix/high quality images memory overload

### DIFF
--- a/packages/camera/src/components/Camera/index.js
+++ b/packages/camera/src/components/Camera/index.js
@@ -9,6 +9,8 @@ import Webcam from 'react-webcam';
 import { findDevices, findBestCandidate, setVideoSource } from './utils';
 import styles from './styles';
 
+const devTools = process.env.NODE_ENV !== 'production';
+
 const { getSize } = utils.styles;
 
 const Video = React.forwardRef(
@@ -44,6 +46,16 @@ const Camera = ({ children, containerStyle, onCameraReady, title }, ref) => {
 
       if (utils.getOS() === 'iOS') {
         const uri = videoRef.current.getScreenshot();
+
+        // FOR TESTING
+        if (devTools) {
+          const img = document.createElement('img');
+          img.src = uri;
+          img.onload = () => {
+            alert(`${img.width}x${img.height}`);
+          };
+        }
+
         return { uri };
       }
 

--- a/packages/camera/src/components/Camera/utils.js
+++ b/packages/camera/src/components/Camera/utils.js
@@ -8,12 +8,18 @@ export const whitelist = [
 //   height: 1440,
 //   ratio: '16:9',
 // },
-  // {
-  //   label: 'FHD 4:3',
-  //   width: 1920,
-  //   height: 1440,
-  //   ratio: '4:3',
-  // },
+  {
+    label: 'QXGA',
+    width: 2048,
+    height: 1536,
+    ratio: '4:3',
+  },
+  {
+    label: 'FHD 4:3',
+    width: 1920,
+    height: 1440,
+    ratio: '4:3',
+  },
   {
     label: 'FHD 16:9',
     width: 1920,

--- a/packages/camera/src/components/Camera/utils.js
+++ b/packages/camera/src/components/Camera/utils.js
@@ -1,32 +1,35 @@
 import 'webrtc-adapter';
 import { utils } from '@monkvision/toolkit';
 
-export const whitelist = [{
-  label: '2K',
-  width: 2560,
-  height: 1440,
-  ratio: '16:9',
-}, {
-  label: 'FHD 4:3',
-  width: 1920,
-  height: 1440,
-  ratio: '4:3',
-}, {
-  label: 'FHD 16:9',
-  width: 1920,
-  height: 1080,
-  ratio: '16:9',
-}, {
-  label: 'UXGA',
-  width: 1600,
-  height: 1200,
-  ratio: '4:3',
-}, {
-  label: 'HD(720p)',
-  width: 1280,
-  height: 720,
-  ratio: '16:9',
-}];
+export const whitelist = [
+//   {
+//   label: '2K',
+//   width: 2560,
+//   height: 1440,
+//   ratio: '16:9',
+// },
+  // {
+  //   label: 'FHD 4:3',
+  //   width: 1920,
+  //   height: 1440,
+  //   ratio: '4:3',
+  // },
+  {
+    label: 'FHD 16:9',
+    width: 1920,
+    height: 1080,
+    ratio: '16:9',
+  }, {
+    label: 'UXGA',
+    width: 1600,
+    height: 1200,
+    ratio: '4:3',
+  }, {
+    label: 'HD(720p)',
+    width: 1280,
+    height: 720,
+    ratio: '16:9',
+  }];
 
 export function captureImageContext(video, { width, height }) {
   const canvas = document.createElement('canvas');


### PR DESCRIPTION
ALL CONTRIBUTIONS WILL BE REVIEWED BY AT LEAST ONE OF OUR FRONTEND TEAM MEMBERS.

<!--- Before all please request a review from your team leader -->
<!--- and members who might be interested in this PR  -->

<!--- in case this is a new idea proposal please use the NEW_IDEA_PROPOSAL template by adding -->
<!--- ?template=NEW_IDEA_PROPOSAL.md to this page url -->

## Technical description
<!--- Describe your changes technically in detail -->
I noticed that when disabling the 2K resolution, the camera works just fine on IOS, so I added a near 2K resolution QXGA (2048x1536 4:3).
Not sure if we can consider it as a fix.

## Related to
<!--- Link the PR to an issue or a board ticket. -->

This PR is related to [High quality camera crashes](https://monkvision.atlassian.net/browse/MN-63)

## About Tests

<!--- Please provide all devices used while testing -->
Tested on the following devices

- Ios chrome



## Screenshots (optional):

*This Pull Request template has been written and generated by Monk JS repository.*

