### PR TITLE
Fixed onCaptureTourFinish getting called 2 times

### DIFF
--- a/packages/camera/src/components/Capture/hooks.js
+++ b/packages/camera/src/components/Capture/hooks.js
@@ -162,9 +162,6 @@ export function useStartUploadAsync({
         payload: { id, status: 'pending', label },
       });
 
-      // call onFinish callback when capturing the last picture
-      if (ids[ids.length - 1] === id) { onFinish(); log([`Capture tour has been finished`]); }
-
       const fileType = Platform.OS === 'web' ? 'webp' : 'jpg';
       const filename = `${id}-${inspectionId}.${fileType}`;
       const multiPartKeys = { image: 'image', json: 'json', filename, type: `image/${fileType}` };


### PR DESCRIPTION
ALL CONTRIBUTIONS WILL BE REVIEWED BY AT LEAST ONE OF OUR FRONTEND TEAM MEMBERS.

<!--- Before all please request a review from your team leader -->
<!--- and members who might be interested in this PR  -->

<!--- in case this is a new idea proposal please use the NEW_IDEA_PROPOSAL template by adding -->
<!--- ?template=NEW_IDEA_PROPOSAL.md to this page url -->

## Technical description
<!--- Describe your changes technically in detail -->
Fixed `onCaptureTourFinish` capture prop getting called two times, basically we don't need it on line 157 because we are calling it bellow after the upload finish (in both cases fulfilled and rejected).

See line 207 and 220.

## Related to
<!--- Link the PR to an issue or a board ticket. -->

This PR is related to Capture component.

## About Tests

<!--- Please provide all devices used while testing -->
Tested on the following devices

- Web chrome

<!--- Steps in details to reproduce the solved issue use cases and to test the solution -->
Steps to reproduce

1. Pass a callback to onCaptureTourFinish

## Screenshots (optional):

*This Pull Request template has been written and generated by Monk JS repository.*

