### PR TITLE
Removed stream cleanup function from useUserMedia, and added a new me…

### DIFF
--- a/packages/camera/src/components/Camera/hooks/useCamera.js
+++ b/packages/camera/src/components/Camera/hooks/useCamera.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { utils } from '@monkvision/toolkit';
 
 import useUserMedia from './useUserMedia';
@@ -67,6 +67,11 @@ export default function useCamera({ width, height }, options) {
       videoRef.current.pause();
     }
   };
+  const stopStream = useCallback(() => {
+    if (stream?.getTracks) { stream.getTracks().forEach((track) => track.stop()); }
+    if (stream?.getAudioTracks) { stream.getAudioTracks().map((track) => track.stop()); }
+    if (stream?.stop) { stream.stop(); }
+  }, [stream]);
 
-  return { videoRef, takePicture, resumePreview, pausePreview };
+  return { videoRef, takePicture, resumePreview, pausePreview, stopStream };
 }

--- a/packages/camera/src/components/Camera/hooks/useCamera.js
+++ b/packages/camera/src/components/Camera/hooks/useCamera.js
@@ -73,5 +73,5 @@ export default function useCamera({ width, height }, options) {
     if (stream?.stop) { stream.stop(); }
   }, [stream]);
 
-  return { videoRef, takePicture, resumePreview, pausePreview, stopStream };
+  return { videoRef, takePicture, resumePreview, pausePreview, stopStream, stream };
 }

--- a/packages/camera/src/components/Camera/hooks/useUserMedia.js
+++ b/packages/camera/src/components/Camera/hooks/useUserMedia.js
@@ -24,18 +24,9 @@ function useUserMedia(constraints = { audio: false, video: false }) {
 
     getUserMedia();
 
-    return () => {
-      didCancel = true;
+    if (!stream) { return () => {}; }
 
-      if (!stream) { return; }
-
-      // stopping video and audio trackers
-      if (stream.getVideoTracks) { stream.getVideoTracks().map((track) => track.stop()); }
-      if (stream.getAudioTracks) { stream.getAudioTracks().map((track) => track.stop()); }
-
-      // stopping the stream
-      if (stream.stop) { stream.stop(); }
-    };
+    return () => { didCancel = true; };
   }, [constraints, stream, error]);
 
   return { stream, error };

--- a/packages/camera/src/components/Camera/index.js
+++ b/packages/camera/src/components/Camera/index.js
@@ -27,12 +27,13 @@ function Camera({ children, containerStyle, onCameraReady, title }, ref) {
     resumePreview,
     pausePreview,
     stopStream,
+    stream,
   } = useCamera(canvasResolution, {
     onCameraReady,
     video: { facingMode, width: canvasResolution.width, height: canvasResolution.height },
   });
 
-  useImperativeHandle(ref, () => ({ takePicture, resumePreview, pausePreview }));
+  useImperativeHandle(ref, () => ({ takePicture, resumePreview, pausePreview, stream }));
 
   // stopping the stream when the comopnent unmount
   useEffect(() => stopStream, [stopStream]);

--- a/packages/camera/src/components/Camera/index.js
+++ b/packages/camera/src/components/Camera/index.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, useImperativeHandle } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle } from 'react';
 import createElement from 'react-native-web/dist/exports/createElement';
 import PropTypes from 'prop-types';
 
@@ -21,16 +21,21 @@ const getLandscapeScreenDimentions = () => {
 };
 
 function Camera({ children, containerStyle, onCameraReady, title }, ref) {
-  const { videoRef, takePicture, resumePreview, pausePreview } = useCamera(canvasResolution, {
+  const {
+    videoRef,
+    takePicture,
+    resumePreview,
+    pausePreview,
+    stopStream,
+  } = useCamera(canvasResolution, {
     onCameraReady,
-    video: {
-      facingMode,
-      width: canvasResolution.width,
-      height: canvasResolution.height,
-    },
+    video: { facingMode, width: canvasResolution.width, height: canvasResolution.height },
   });
 
   useImperativeHandle(ref, () => ({ takePicture, resumePreview, pausePreview }));
+
+  // stopping the stream when the comopnent unmount
+  useEffect(() => stopStream, [stopStream]);
 
   return (
     <View

--- a/packages/camera/src/components/Controls/hooks.js
+++ b/packages/camera/src/components/Controls/hooks.js
@@ -3,7 +3,7 @@ import Actions from '../../actions';
 
 const useHandlers = ({
   onStartUploadPicture, onFinishUploadPicture, checkComplianceAsync,
-  enableComplianceCheck, unControlledState,
+  enableComplianceCheck, unControlledState, stream,
 }) => {
   const [complianceToCheck, setComplianceToCheck] = useState([]);
   /**
@@ -38,6 +38,9 @@ const useHandlers = ({
   }, [complianceToCheck, unControlledState.uploads.state]);
 
   const capture = useCallback(async (controlledState, api, event) => {
+    /** if the stream is not ready, we should not proceed to the capture callback, it will crash */
+    if (!stream) { return; }
+
     /** `controlledState` is the state at a moment `t`, so it will be used for function that doesn't
      *  need state updates
      * `unControlledState` is the updated state, so it will be used for function that depends on
@@ -70,7 +73,7 @@ const useHandlers = ({
       onFinishUploadPicture(state, api);
       goNextSight();
     }
-  }, [enableComplianceCheck, onFinishUploadPicture, onStartUploadPicture]);
+  }, [enableComplianceCheck, onFinishUploadPicture, onStartUploadPicture, stream]);
 
   const retakeAll = useCallback((sightsIdsToRetake, states, setSightsIds) => {
     // adding an initialState that will hold new compliances with `requestCount = 1`

--- a/packages/camera/src/components/Controls/index.js
+++ b/packages/camera/src/components/Controls/index.js
@@ -39,6 +39,7 @@ export default function Controls({
     onStartUploadPicture,
     onFinishUploadPicture,
     enableComplianceCheck,
+    stream: api.camera.current?.stream,
   });
 
   const handlePress = useCallback(({ onPress }) => (e) => {
@@ -74,7 +75,10 @@ export default function Controls({
 
 Controls.propTypes = {
   api: PropTypes.shape({
-    camera: PropTypes.shape({ takePictureAsync: PropTypes.func }),
+    camera: PropTypes.shape({
+      current: PropTypes.objectOf(PropTypes.any),
+      takePictureAsync: PropTypes.func,
+    }),
     checkComplianceAsync: PropTypes.func,
     goNextSight: PropTypes.func,
     goPrevSight: PropTypes.func,


### PR DESCRIPTION
…thod to Camera element, stopStream

ALL CONTRIBUTIONS WILL BE REVIEWED BY AT LEAST ONE OF OUR FRONTEND TEAM MEMBERS.

<!--- Before all please request a review from your team leader -->
<!--- and members who might be interested in this PR  -->

<!--- in case this is a new idea proposal please use the NEW_IDEA_PROPOSAL template by adding -->
<!--- ?template=NEW_IDEA_PROPOSAL.md to this page url -->

## Technical description
<!--- Describe your changes technically in detail -->
This feature allows us to stop and clear the stream, when we unmount the component, actually useful in cases such as our webapp workflow, when we switch between modes.

Also added `stream` to the camera `ref`, so it can be accessible from other component via `ref`, and added we block the user from taking pictures if the stream is not ready, not really fan of it but might be useful in some cases better than throwing an error.

Tested it 2 times, and I completed the whole capture workflow on iPhone 8.

## About Tests

<!--- Please provide all devices used while testing -->
Tested on the following devices

- Web chrome
- Chrome iOS

<!--- Steps in details to reproduce the solved issue use cases and to test the solution -->
Steps to reproduce

1. When finishing from a capture mode (e.g vin) and return to landing, the camera green dot at the top of the screen should disappear.
2. Expected to be canceled each time we remove the camera from the dom.


## Screenshots (optional):

*This Pull Request template has been written and generated by Monk JS repository.*

