### PR TITLE
Fix retake/retake all + reupload buttons at the upload center step

### DIFF
--- a/packages/camera/src/components/Controls/hooks.js
+++ b/packages/camera/src/components/Controls/hooks.js
@@ -44,7 +44,7 @@ const useHandlers = ({
 
   const capture = useCallback(async (controlledState, api, event) => {
     /** if the stream is not ready, we should not proceed to the capture callback, it will crash */
-    if (!stream) { return; }
+    if (!stream && !api.camera.current?.stream) { return; }
 
     /** `controlledState` is the state at a moment `t`, so it will be used for function that doesn't
      *  need state updates

--- a/packages/camera/src/components/UploadCenter/hooks.js
+++ b/packages/camera/src/components/UploadCenter/hooks.js
@@ -153,30 +153,33 @@ export const useHandlers = ({
   // retake all rejected/non-compliant pictures at once
   const handleRetakeAll = useCallback(() => {
     // adding an initialState that will hold new compliances with `requestCount = 1`
-    const complianceInitialState = { id: '', status: 'idle', error: null, requestCount: 1, result: null, imageId: null };
+    const complianceInitialState = { id: '', status: 'idle', error: null, requestCount: 0, result: null, imageId: null };
     const complianceState = {};
     ids.forEach((id) => { complianceState[id] = { ...complianceInitialState, id }; });
 
     // reset uploads state with the new incoming ones
     uploads.dispatch({ type: Actions.uploads.RESET_UPLOADS, ids: { sightIds: ids } });
 
+    // reset compliance state with the new incoming ones
+    compliance.dispatch({ type: Actions.compliance.RESET_COMPLIANCE, ids: { sightIds: ids } });
+
     // reset sightrs state with the new incoming ones
     sights.dispatch({ type: Actions.sights.RESET_TOUR, payload: { sightIds: ids } });
 
     // run a custom callback at the retake all time
     onRetakeAll();
-  }, [ids, onRetakeAll, sights, uploads]);
+  }, [ids, onRetakeAll, sights, uploads, compliance]);
 
   // retake one picture
   const handleRetake = useCallback((id) => {
     // reset upload and compliance info
     compliance.dispatch({
       type: Actions.compliance.UPDATE_COMPLIANCE,
-      payload: { id, status: 'idle', error: null, result: null, imageId: null },
+      payload: { id, status: 'idle', error: null, result: null, imageId: null, requestCount: 0 },
     });
     uploads.dispatch({
       type: Actions.uploads.UPDATE_UPLOAD,
-      payload: { id, status: 'idle', picture: null },
+      payload: { id, status: 'idle', picture: null, uploadCount: 0 },
     });
 
     // remove the picture from the sight and focus on the current sight

--- a/packages/camera/src/hooks/useCompliance/index.js
+++ b/packages/camera/src/hooks/useCompliance/index.js
@@ -40,7 +40,7 @@ function reducer(state, action) {
     case Actions.compliance.UPDATE_COMPLIANCE:
       return ({
         ...state,
-        [id]: { ...prevCompliance, ...action.payload, requestCount },
+        [id]: { ...prevCompliance, requestCount, ...action.payload },
       });
 
     default:

--- a/packages/camera/src/hooks/useUploads/index.js
+++ b/packages/camera/src/hooks/useUploads/index.js
@@ -36,7 +36,7 @@ function reducer(state, action) {
     case Actions.uploads.UPDATE_UPLOAD:
       return ({
         ...state,
-        [id]: { ...prevUpload, ...action.payload, uploadCount },
+        [id]: { ...prevUpload, uploadCount, ...action.payload },
       });
 
     default:


### PR DESCRIPTION
<!--- Please request a review from the leader or members from the FE team  -->

## Technical description
<!--- Describe your changes technically in detail -->

- [x] Feature description...

## Tested on
<!--- Please provide all devices used while testing -->

-
- 

## Steps to reproduce
<!--- Steps in details to reproduce the solved issue use cases  -->

1. Enable Upload center on `InspectionCapture`
2. Run the capture process
3. Click on `Retake a photo` and then `Retake all` (if multiple compliances)
4. Expected to go to the camera screen and be able to take photos
5. Same for the reupload photo. Expected to reupload the photo without going on the camera screen

## Screenshots (optional):

No screenshots.

*This Pull Request template has been written and generated by Monk JS repository.*

