### PR TITLE
Added a new helper to check qhd support for the web, a new prop for t…

### DIFF
--- a/packages/camera/src/components/Camera/index.js
+++ b/packages/camera/src/components/Camera/index.js
@@ -10,10 +10,6 @@ import styles from './styles';
 
 import useCamera from './hooks/useCamera';
 
-const MARK_START = 'mark_start';
-const MARK_END = 'mark_end';
-const MAX_DURATION_FOR_FHD_PICTURE = 250; // in ms
-
 const isMobile = ['iOS', 'Android'].includes(utils.getOS());
 const facingMode = isMobile ? { exact: 'environment' } : 'environment';
 const canvasResolution = { QHD: { width: 2560, height: 1440 }, FHD: { width: 1920, height: 1080 } };
@@ -24,11 +20,19 @@ const getLandscapeScreenDimensions = () => {
   return { height: Math.min(width, height), width: Math.max(width, height) };
 };
 
-function Camera({ children, containerStyle, onCameraReady, title, settings }, ref) {
+function Camera({
+  children,
+  containerStyle,
+  onCameraReady,
+  title,
+  settings,
+  enableQHDWhenSupported,
+}, ref) {
   const resolution = useMemo(() => canvasResolution[settings.state.resolution], [settings]);
 
   const setSettings = useCallback(
-    (payload) => settings.dispatch({ type: Actions.settings.UPDATE_SETTINGS, payload }),
+    (r) => settings.dispatch({
+      type: Actions.settings.UPDATE_SETTINGS, payload: { resolution: r } }),
     [resolution],
   );
   const {
@@ -44,26 +48,17 @@ function Camera({ children, containerStyle, onCameraReady, title, settings }, re
   });
 
   useImperativeHandle(ref, () => ({ takePicture, resumePreview, pausePreview, stream }));
-  const delay = useMemo(() => (stream && videoRef.current ? 500 : null), [stream]);
+  const delay = useMemo(
+    () => (enableQHDWhenSupported && stream && videoRef.current ? 500 : null),
+    [stream],
+  );
 
   // stopping the stream when the component unmount
   useEffect(() => stopStream, [stopStream]);
 
-  /** Note(Ilyass): As a solution to measure the device performance, we run a dummy `takePicture()`
-   * using FHD (to calculate the exec time without crashing the app), and we compare the execution
-   * time we get with `MAX_DURATION_FOR_FHD_PICTURE` which is the max duration for `takePicture()`
-   * to be taken by a device that can run QHD.
-   */
   useTimeout(() => {
-    performance.mark(MARK_START);
-    const picture = takePicture(); URL.revokeObjectURL(picture.uri);
-    performance.mark(MARK_END);
-
-    const { duration } = performance.measure('Measuring `takePicture()` execution time', MARK_START, MARK_END);
-
-    if (duration < MAX_DURATION_FOR_FHD_PICTURE) {
-      setSettings('QHD');
-    } else { setSettings('FHD'); }
+    const supportsQHD = utils.inaccuratelyCheckQHDSupport(takePicture);
+    if (supportsQHD) { setSettings('QHD'); } else { setSettings('FHD'); }
   }, delay);
 
   return (
@@ -92,6 +87,7 @@ export default forwardRef(Camera);
 
 Camera.propTypes = {
   containerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  enableQHDWhenSupported: PropTypes.bool,
   onCameraReady: PropTypes.func.isRequired,
   settings: PropTypes.shape({
     dispatch: PropTypes.func,
@@ -102,6 +98,7 @@ Camera.propTypes = {
 
 Camera.defaultProps = {
   containerStyle: null,
+  enableQHDWhenSupported: true,
   settings: { state: { resolution: 'FHD' }, dispatch: () => {} },
   title: '',
 };

--- a/packages/camera/src/components/Capture/capture.js
+++ b/packages/camera/src/components/Capture/capture.js
@@ -47,6 +47,7 @@ const Capture = forwardRef(({
   controls,
   controlsContainerStyle,
   enableComplianceCheck,
+  enableQHDWhenSupported,
   footer,
   fullscreen,
   inspectionId,
@@ -327,6 +328,7 @@ const Capture = forwardRef(({
           ratio={settings.ratio}
           pictureSize={settings.pictureSize}
           settings={settings}
+          enableQHDWhenSupported={enableQHDWhenSupported}
         >
           {children}
         </Camera>
@@ -359,6 +361,7 @@ Capture.propTypes = {
   })),
   controlsContainerStyle: PropTypes.objectOf(PropTypes.any),
   enableComplianceCheck: PropTypes.bool,
+  enableQHDWhenSupported: PropTypes.bool,
   footer: PropTypes.element,
   fullscreen: PropTypes.objectOf(PropTypes.any),
   initialState: PropTypes.shape({
@@ -455,6 +458,7 @@ Capture.propTypes = {
 Capture.defaultProps = {
   controls: [],
   controlsContainerStyle: {},
+  enableQHDWhenSupported: true,
   footer: null,
   fullscreen: null,
   initialState: {

--- a/packages/toolkit/src/utils/index.js
+++ b/packages/toolkit/src/utils/index.js
@@ -47,6 +47,25 @@ function supportsWebP() {
   return false;
 }
 
+/**
+ * Inaccurately checking if the device supports taking QHD images on the web
+ * @param {func} takePicture
+ * @returns {bool}
+ */
+function inaccuratelyCheckQHDSupport(takePicture) {
+  const MARK_START = 'mark_start';
+  const MARK_END = 'mark_end';
+  const MAX_DURATION_FOR_FHD_PICTURE = 250; // in ms
+
+  performance.mark(MARK_START);
+  const picture = takePicture(); URL.revokeObjectURL(picture.uri);
+  performance.mark(MARK_END);
+
+  const { duration } = performance.measure('Measuring `takePicture()` execution time', MARK_START, MARK_END);
+
+  return duration < MAX_DURATION_FOR_FHD_PICTURE;
+}
+
 export default {
   styles,
   log,
@@ -54,4 +73,5 @@ export default {
   getOS,
   useNativeDriver,
   supportsWebP,
+  inaccuratelyCheckQHDSupport,
 };

--- a/website/docs/js/api/components/Capture.md
+++ b/website/docs/js/api/components/Capture.md
@@ -149,6 +149,11 @@ A rendered element to be display has footer of the Sights scroll list
 
 Props inherited from `Button`
 
+## enableQHDWhenSupported
+`PropTypes.bool`
+
+Automatically enable `QHD` resolution, by default it's `true` (for web only).
+
 ## initialState
 `PropTypes.state`
 
@@ -351,13 +356,18 @@ console.log(state); // { isReady, settings, sights, uploads, compliance };
 ```
 
 ### settings
+````js
+const settings = useSettings({ camera, initialState });
+console.log(settings); // { state, distpatch }
+console.log(settings.state); // {current: { id, index, metadata }, ids, remainingPictures, takenPictures, tour }
+````
 See [Expo Camera Props](https://docs.expo.dev/versions/latest/sdk/camera/#props)
 
 ### sights
 ````js
 const sights = useSights({ sightIds });
 console.log(sights); // { state, distpatch }
-console.log(sights.state); // {current: { id, index, metadata }, ids, remainingPictures, takenPictures, tour }
+console.log(sights.state); // { resolution, ratio, zoom, type }
 ````
 
 ### uploads


### PR DESCRIPTION
…he automatic use of QHD when supported, and updated the docs

<!--- Please request a review from the leader or members from the FE team  -->

## Technical description
<!--- Describe your changes technically in detail -->

- [x] Added a new utility `inaccuratelyCheckQHDSupport` to **_toolkit_**, that takes the `takePicture` as an argument and return if the device supports QHD resolution(inaccurately).
- [x] Added a new prop `enableQHDWhenSupported`, that will enable QHD resolution when supported (`true` by default). 
- [x] Updated the docs for the new `useSettings`, `inaccuratelyCheckQHDSupport`, and `enableQHDWhenSupported`.

## Tested on
<!--- Please provide all devices used while testing -->

- Macbook air M1, chrome.
- iPhone 8

## Steps to reproduce
<!--- Steps in details to reproduce the solved issue use cases  -->

1. QHD should be enabled by default if the device supports it, try disable `enableQHDWhenSupported`.
2. Try run `utils.inaccuratelyCheckQHDSupport`, and check for the QHD support.

## Screenshots (optional):

No screenshots.

*This Pull Request template has been written and generated by Monk JS repository.*

