### PR TITLE
Added logs when taking a picture

### DIFF
--- a/packages/camera/src/components/Capture/hooks.js
+++ b/packages/camera/src/components/Capture/hooks.js
@@ -18,11 +18,13 @@ const handleCompress = async (picture) => {
   // no need to compress images under 3mb
   if (res.data.size / 1024 < 3000) {
     URL.revokeObjectURL(picture.uri);
+    log([`An image has been taken, with size: ${(res.data.size / 1024 / 1024).toFixed(2)}Mo, and resolution: ${picture.width}x${picture.height}`]);
     return res.data;
   }
 
   const compressed = await compressAccurately(res.data, 3000);
   URL.revokeObjectURL(picture.uri);
+  log([`An image has been taken, with size: ${(res.data.size / 1024 / 1024).toFixed(2)}Mo, optimized to ${(compressed.size / 1024 / 1024).toFixed(2)}Mo, and resolution: ${picture.width}x${picture.height}`]);
 
   return compressed || res.data;
 };
@@ -309,7 +311,7 @@ export function useCheckComplianceAsync({ compliance, inspectionId, sightId: cur
         payload: { id: sightId, status: 'pending', imageId },
       });
 
-      const result = await monk.entity.image.getOne({ inspectionId, imageId });
+      const result = await monk.entity.image.getOne(inspectionId, imageId);
 
       const carCov = result.axiosResponse.data.compliances.coverage_360;
       const iqa = result.axiosResponse.data.compliances.image_quality_assessment;


### PR DESCRIPTION
<!--- Please request a review from the leader or members from the FE team  -->

## Technical description
<!--- Describe your changes technically in detail -->

- [x] Brought back the logs when taking a picture, this was implemented before on main, but I couldn't find it... I believe this was removed by mistake...

## Tested on
<!--- Please provide all devices used while testing -->

- iPhone 8/chrome
- M1 air/chrome

## Steps to reproduce
<!--- Steps in details to reproduce the solved issue use cases  -->

1. Take pictures
2. Check the logs or see them on sentry

## Screenshots (optional):

No screenshots.

*This Pull Request template has been written and generated by Monk JS repository.*

