### PR TITLE
Implemented the allowSkip navigationOption on uploadcenter

### DIFF
--- a/packages/camera/src/components/UploadCenter/button.js
+++ b/packages/camera/src/components/UploadCenter/button.js
@@ -19,9 +19,10 @@ export default function Button({ colors, children, color, ...props }) {
   const composedStyles = useMemo(() => {
     const disabledColor = color.disabled || colors.disabled;
     const backgroundColor = color.background || colors.background;
+
     return {
       backgroundColor: props.disabled ? disabledColor : backgroundColor,
-      opacity: props.disabled ? 0.8 : 1,
+      opacity: props.disabled ? 0.4 : 1,
     };
   }, [color, colors, props.disabled]);
 
@@ -34,6 +35,7 @@ export default function Button({ colors, children, color, ...props }) {
     </TouchableOpacity>
   );
 }
+
 Button.propTypes = {
   children: PropTypes.element.isRequired,
   color: PropTypes.objectOf(PropTypes.string).isRequired,
@@ -43,6 +45,7 @@ Button.propTypes = {
   }).isRequired,
   disabled: PropTypes.bool,
 };
+
 Button.defaultProps = {
   disabled: true,
 };

--- a/packages/camera/src/components/UploadCenter/index.js
+++ b/packages/camera/src/components/UploadCenter/index.js
@@ -183,7 +183,8 @@ export default function UploadCenter({
           colors={colors}
           color={colors.actions.secondary}
           onPress={onComplianceCheckFinish}
-          disabled={isSubmitting || hasAllRejected || !hasFulfilledAllUploads}
+          disabled={isSubmitting || hasAllRejected
+             || !hasFulfilledAllUploads || !navigationOptions.allowSkip}
         >
           <Text style={{ color: colors.actions.secondary.text || colors.text }}>
             {submitButtonLabel}
@@ -259,6 +260,7 @@ UploadCenter.defaultProps = {
   mapTasksToSights: [],
   navigationOptions: {
     retakeMaxTry: 1,
+    allowSkip: true,
   },
   task: 'damage_detection',
 };


### PR DESCRIPTION
<!--- Please request a review from the leader or members from the FE team  -->

## Technical description
<!--- Describe your changes technically in detail -->

- [x] Implemented the prop `navigationsOptions.allowSkip` in upload center

## Tested on
<!--- Please provide all devices used while testing -->

- Mac air/M1 chrome

## Steps to reproduce
<!--- Steps in details to reproduce the solved issue use cases  -->

1. Try add a prop `navigationOptions={{ allowSkip: false }}`, to the capture component.
2. Take the capture tour, when you land on the upload center, the Skip button should be disabled.

## Screenshots (optional):

No screenshots.

*This Pull Request template has been written and generated by Monk JS repository.*

