### PR TITLE
Fixed the capture layout issue

### DIFF
--- a/packages/camera/src/components/Capture/capture.js
+++ b/packages/camera/src/components/Capture/capture.js
@@ -1,5 +1,5 @@
 import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react';
-import { ActivityIndicator, StyleSheet, useWindowDimensions, View } from 'react-native';
+import { ActivityIndicator, Platform, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { utils } from '@monkvision/toolkit';
 import PropTypes from 'prop-types';
 
@@ -26,6 +26,17 @@ import {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    ...Platform.select({
+      web: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        flex: '1 1 0%',
+        display: 'flex',
+      },
+    }),
   },
   loading: {
     flex: 1,


### PR DESCRIPTION
<!--- Please request a review from the leader or members from the FE team  -->

## Technical description
<!--- Describe your changes technically in detail -->

- [x] Fixed capture layout on web

## Tested on
<!--- Please provide all devices used while testing -->

- Mac Air m1/chrome

## Steps to reproduce
<!--- Steps in details to reproduce the solved issue use cases  -->

1. On cra apps Capture view should fit the whole screen (no empty margins)

## Screenshots (optional):

No screenshots.

*This Pull Request template has been written and generated by Monk JS repository.*

