### PR TITLE
Added fullscreen toggle, without toggle off

### DIFF
--- a/src/screens/InspectionCapture/settings.js
+++ b/src/screens/InspectionCapture/settings.js
@@ -1,25 +1,45 @@
 import React, { forwardRef, useImperativeHandle, useState } from 'react';
-import { Pressable, View } from 'react-native';
-import { useTheme, Menu } from 'react-native-paper';
+import { Pressable, useWindowDimensions, View } from 'react-native';
+import { useTheme, Menu, List } from 'react-native-paper';
 import PropTypes from 'prop-types';
 
 import { Actions } from '@monkvision/camera';
 
 import styles from './styles';
 
+const requestScreenful = () => {
+  document.fullscreenEnabled = document.fullscreenEnabled
+   || document.mozFullScreenEnabled || document.documentElement.webkitRequestFullScreen;
+
+  function requestFullscreen(element) {
+    if (element.requestFullscreen) {
+      element.requestFullscreen();
+    } else if (element.mozRequestFullScreen) {
+      element.mozRequestFullScreen();
+    } else if (element.webkitRequestFullScreen) {
+      element.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
+    }
+  }
+
+  if (document.fullscreenEnabled) {
+    requestFullscreen(document.documentElement);
+  }
+};
+
 const modals = {
-  default: [{ title: 'Resolution', value: 'resolution' }, { title: 'Ratio', value: 'ratio' }],
+  default: [{ title: 'Resolution', value: 'resolution' }, { title: 'Fullscreen', value: 'fullscreen' }],
   resolution: [{ title: 'FHD', value: 'FHD' }, { title: 'QHD', value: 'QHD' }],
-  ratio: [{ title: '4:3', value: '4:3' }, { title: '16:9', value: '16:9' }],
 };
 
 const Settings = forwardRef(({ settings }, ref) => {
   const { colors } = useTheme();
+  const { width, height } = useWindowDimensions();
   const [modal, setModal] = useState({ visible: false, name: null });
   const handleClose = () => setModal({ visible: false, name: null });
 
   const handleSelect = (name) => {
     // select only value that are not one of the `modals` keys
+    if (name === 'fullscreen') { requestScreenful(); return; }
     if (Object.keys(modals).includes(name)) { setModal({ visible: true, name }); return; }
 
     settings.dispatch({
@@ -36,6 +56,7 @@ const Settings = forwardRef(({ settings }, ref) => {
   return (
     <>
       <View style={[styles.settings, { backgroundColor: colors.background }]}>
+        <List.Subheader>Settings</List.Subheader>
         {modals[modal.name].map((item) => (
           <Menu.Item
             onPress={() => handleSelect(item.value)}
@@ -49,7 +70,7 @@ const Settings = forwardRef(({ settings }, ref) => {
         ))}
       </View>
       <Pressable
-        style={[styles.pressOutside, { backgroundColor: colors.background }]}
+        style={[styles.pressOutside, { width, height, backgroundColor: colors.background }]}
         onPress={handleClose}
       />
     </>

--- a/src/screens/InspectionCapture/styles.js
+++ b/src/screens/InspectionCapture/styles.js
@@ -24,8 +24,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     left: 0,
-    width,
-    height,
   },
   blur: {
     width, height,


### PR DESCRIPTION
<!--- Please request a review from the leader or members from the FE team  -->

## Technical description
<!--- Describe your changes technically in detail -->

- [x] Replaced ratio setting with fullscreen, but without toggle off

## Tested on
<!--- Please provide all devices used while testing -->

- Mac air m1/chrome

## Steps to reproduce
<!--- Steps in details to reproduce the solved issue use cases  -->

1. Open the camera
2. Open the settings
3. Hit fullscreen

## Screenshots (optional):

No screenshots.

*This Pull Request template has been written and generated by Monk JS repository.*

