### PR TITLE
Fixed when an image get a null compliance and blocks the all the queue

### DIFF
--- a/packages/camera/src/components/Capture/hooks.js
+++ b/packages/camera/src/components/Capture/hooks.js
@@ -357,6 +357,13 @@ export function useCheckComplianceAsync({
       const carCov = result.axiosResponse.data.compliances.coverage_360;
       const iqa = result.axiosResponse.data.compliances.image_quality_assessment;
 
+      if ((!carCov || carCov.status === 'TODO') || iqa.status === 'TODO') {
+        dispatch({
+          type: Actions.compliance.UPDATE_COMPLIANCE,
+          payload: { id: sightId, status: 'unsatisfied', result: result.axiosResponse, imageId },
+        });
+      }
+
       if ((!carCov || carCov.status === 'DONE') && (iqa.status === 'DONE')) {
         dispatch({
           type: Actions.compliance.UPDATE_COMPLIANCE,

--- a/packages/camera/src/components/UploadCenter/UploadCard/hooks/useStatus.js
+++ b/packages/camera/src/components/UploadCenter/UploadCard/hooks/useStatus.js
@@ -5,6 +5,8 @@ export default function useStatus({ compliance, upload }) {
     upload.status === 'pending' || (upload.status === 'fulfilled' && compliance.status === 'pending')
   ), [compliance, upload]);
 
+  const isComplianceUnknown = useMemo(() => compliance.status === 'unsatisfied', [compliance]);
+
   const isUploadFailed = useMemo(() => upload.error, [upload.error]);
 
   const { isComplianceIdle, isComplianceFailed } = useMemo(() => ({
@@ -12,14 +14,11 @@ export default function useStatus({ compliance, upload }) {
     isComplianceIdle: compliance.status === 'idle',
   }), [compliance.status]);
 
-  const isComplianceUnknown = useMemo(() => {
-    const allCompliancesAreUnkown = compliance.result
-        && Object.values(compliance.result?.data?.compliances).every(
-          (c) => c.is_compliant === null,
-        );
-
-    return !isPending && allCompliancesAreUnkown;
-  }, [compliance, isPending]);
-
-  return { isPending, isUploadFailed, isComplianceIdle, isComplianceFailed, isComplianceUnknown };
+  return {
+    isPending,
+    isUploadFailed,
+    isComplianceIdle,
+    isComplianceFailed,
+    isComplianceUnknown,
+  };
 }

--- a/packages/camera/src/components/UploadCenter/UploadCard/hooks/useVariant.js
+++ b/packages/camera/src/components/UploadCenter/UploadCard/hooks/useVariant.js
@@ -1,0 +1,46 @@
+import { useMemo } from 'react';
+
+export default function useThumbnail({
+  colors,
+  isPending, isComplianceFailed, isComplianceIdle, isComplianceUnknown, isUploadFailed,
+  handleReupload, handleRecheck, handleRetake,
+}) {
+  return useMemo(() => {
+    if (isPending) { return { callback: null, color: colors.placeholder }; }
+    if (isUploadFailed) {
+      return {
+        label: 'Reupload picture',
+        icon: 'refresh-circle',
+        callback: handleReupload,
+        sublable: 'press here to reupload...',
+        color: colors.error,
+      };
+    }
+    if (isComplianceIdle) {
+      return {
+        label: 'In queue',
+        icon: 'clock',
+        callback: null,
+        color: colors.disabled,
+      };
+    }
+    if (isComplianceFailed || isComplianceUnknown) {
+      return {
+        label: 'Recheck picture',
+        icon: 'alert-circle',
+        callback: handleRecheck,
+        sublable: 'press here to recheck...',
+        color: colors.disabled,
+      };
+    }
+
+    return {
+      label: 'Retake picture',
+      icon: 'camera-retake',
+      callback: handleRetake,
+      sublable: 'press here to retake...',
+      color: colors.accent,
+    };
+  }, [isPending, isComplianceFailed, isComplianceIdle, isUploadFailed,
+    handleReupload, handleRecheck, handleRetake, colors]);
+}

--- a/packages/camera/src/components/UploadCenter/hooks/useComplianceIds.js
+++ b/packages/camera/src/components/UploadCenter/hooks/useComplianceIds.js
@@ -68,6 +68,11 @@ export default function useComplianceIds({ sights, compliance, uploads, navigati
     .sort(sortByIndex)
     .map(({ id }) => id), [sortByIndex, uploads.state]);
 
+  const unsatisfiedCompliances = useMemo(() => Object.values(compliance.state)
+    .filter(({ status }) => status === 'unsatisfied')
+    .sort(sortByIndex)
+    .map(({ id }) => id), [sortByIndex, compliance.state]);
+
   const complianceIdsWithError = useMemo(() => {
     if (fulfilledCompliance) {
       return Object.values(fulfilledCompliance)
@@ -120,6 +125,7 @@ export default function useComplianceIds({ sights, compliance, uploads, navigati
     ...unfulfilledComplianceIds,
     ...uploadIdsWithError,
     ...complianceIdsWithError,
+    ...unsatisfiedCompliances,
   ])],
   state: {
     uploads,

--- a/packages/camera/src/components/UploadCenter/hooks/useComplianceIds.js
+++ b/packages/camera/src/components/UploadCenter/hooks/useComplianceIds.js
@@ -54,16 +54,11 @@ export default function useComplianceIds({ sights, compliance, uploads, navigati
     .map(({ id }) => id), [sortByIndex, uploads.state]);
 
   const unfulfilledComplianceIds = useMemo(() => Object.values(compliance.state)
-    .filter(({ status, requestCount, result }) => {
-      const currentCompliance = result?.data?.compliances;
-      const hasNullCompliances = result && Object.values(currentCompliance).some((c) => hasTodo(c));
-
-      const hasTodoCompliancesAndNotReachedMaxRetries = hasNullCompliances && requestCount < 2;
+    .filter(({ status, requestCount }) => {
       const isPendingAndHasNotReachedMaxRetries = ['pending', 'idle'].includes(status) && requestCount <= navigationOptions.retakeMaxTry;
       const unfulfilled = status === 'rejected';
 
-      return isPendingAndHasNotReachedMaxRetries || hasTodoCompliancesAndNotReachedMaxRetries
-      || unfulfilled;
+      return isPendingAndHasNotReachedMaxRetries || unfulfilled;
     })
     .sort(sortByIndex)
     .map(({ id }) => id), [compliance.state, navigationOptions.retakeMaxTry, sortByIndex]);


### PR DESCRIPTION
<!--- Please request a review from the leader or members from the FE team  -->

## Technical description
<!--- Describe your changes technically in detail -->

- [x] Fixed when an upload gets a null compliance (before we were hiding it as compliant after 3 retries), but now we have the ability to re check compliance manually (used a new compliance status `unsatisfied`, which presents compliances that are null)

## Tested on
<!--- Please provide all devices used while testing -->

- Mac air chrome

## Steps to reproduce
<!--- Steps in details to reproduce the solved issue use cases  -->

1. It is very rare when we get a null compliance, but in order to test just take the tour
2. On the upload center the flow shouldn't be stuck in the queue (at least on of the compliances should .

## Screenshots (optional):

No screenshots.

*This Pull Request template has been written and generated by Monk JS repository.*

