### PR TITLE
Fixed a typo that was preventing the modal from being opened

### DIFF
--- a/src/screens/InspectionCapture/settings.js
+++ b/src/screens/InspectionCapture/settings.js
@@ -68,7 +68,7 @@ const Settings = forwardRef(({ settings }, ref) => {
   }, [modals, requestFullscreen, modal.name]);
 
   useImperativeHandle(ref, () => ({
-    open: () => handleSelect(settingsOptions.FULLSCREEN.DEFAULT),
+    open: () => handleSelect(settingsOptions.DEFAULT),
   }));
 
   if (!modal.visible) { return null; }


### PR DESCRIPTION
<!--- Please request a review from the leader or members from the FE team  -->

## Technical description
<!--- Describe your changes technically in detail -->

- [x] Fixed a typo inside capture settings (was preventing the settings from being opened)

## Tested on
<!--- Please provide all devices used while testing -->

- Mac Web chrome
- iphone 8 chrome

## Steps to reproduce
<!--- Steps in details to reproduce the solved issue use cases  -->

1. Open the settings
2. Should be open

## Screenshots (optional):

No screenshots.

*This Pull Request template has been written and generated by Monk JS repository.*

