### PR TITLE
Return null if the rotation is portrait

### DIFF
--- a/src/screens/InspectionCapture/settings.js
+++ b/src/screens/InspectionCapture/settings.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 
 import { Actions } from '@monkvision/camera';
 
+import { useMediaQuery } from 'react-responsive';
 import styles from './styles';
 import useFullscreen from './useFullscreen';
 
@@ -18,6 +19,8 @@ const settingsOptions = {
 };
 
 const Settings = forwardRef(({ settings }, ref) => {
+  const portraitMediaQuery = useMediaQuery({ query: '(orientation: portrait)' });
+
   const { colors } = useTheme();
   const { width, height } = useWindowDimensions();
   const [modal, setModal] = useState({ visible: false, name: null });
@@ -71,7 +74,8 @@ const Settings = forwardRef(({ settings }, ref) => {
     open: () => handleSelect(settingsOptions.DEFAULT),
   }));
 
-  if (!modal.visible) { return null; }
+  if (!modal.visible || portraitMediaQuery) { return null; }
+
   return (
     <>
       <View style={[styles.settings, { backgroundColor: colors.background }]}>


### PR DESCRIPTION
<!--- Please request a review from the leader or members from the FE team  -->

## Technical description
<!--- Describe your changes technically in detail -->

- [x] If the orientation is portrait, the settings modal will return null

## Tested on
<!--- Please provide all devices used while testing -->

- Mac m1 chrome

## Steps to reproduce
<!--- Steps in details to reproduce the solved issue use cases  -->

1. Open the camera settings menu
2. Rotate to portrait
3. Expected: the menu should be closed 

## Screenshots (optional):

No screenshots.

*This Pull Request template has been written and generated by Monk JS repository.*

