### PR TITLE
Enhancement Damage highlight refacto

### DIFF
--- a/packages/visualization/package.json
+++ b/packages/visualization/package.json
@@ -39,6 +39,7 @@
     "release": "release-it"
   },
   "dependencies": {
+    "axios": "^0.24.0",
     "@unimodules/core": "^7.1.2",
     "@unimodules/react-native-adapter": "^6.3.9",
     "lodash.isboolean": "^3.0.3",
@@ -52,6 +53,7 @@
     "release-it": "*"
   },
   "peerDependencies": {
+    "@monkvision/corejs": "3.2.3",
     "react": "*",
     "react-native": "*",
     "react-native-svg": "*"

--- a/packages/visualization/src/components/DamageAnnotations/index.js
+++ b/packages/visualization/src/components/DamageAnnotations/index.js
@@ -3,6 +3,7 @@ import { Platform } from 'react-native';
 import { Circle, ClipPath, Defs, Ellipse, Svg } from 'react-native-svg';
 import { PinchGestureHandler } from 'react-native-gesture-handler';
 import PropTypes from 'prop-types';
+import axios from 'axios';
 
 import monk from '@monkvision/corejs';
 
@@ -23,149 +24,212 @@ const DEFAULT_OPTIONS = {
   },
 };
 
-const DamageAnnotations = forwardRef(({
-  image,
-  inspectionId,
-  options,
-  clip,
-  renderOptions,
-}, ref) => {
-  const [isPointAdded, setIsPointAdded] = useState(false);
-  const [ellipse, setEllipse] = useState(null);
-  const [ellWidth, setEllWidth] = useState(null);
-  const [ellHeight, setEllHeight] = useState(null);
-  const [pos, setPos] = useState(null);
-  const [dragX, setDragX] = useState(false);
-  const [dragY, setDragY] = useState(false);
-  const [dragPos, setDragPos] = useState(false);
+const DamageAnnotations = forwardRef(
+  ({ image, inspectionId, options, clip, renderOptions }, ref) => {
+    const [isPointAdded, setIsPointAdded] = useState(false);
+    const [ellipse, setEllipse] = useState(null);
+    const [ellWidth, setEllWidth] = useState(null);
+    const [ellHeight, setEllHeight] = useState(null);
+    const [pos, setPos] = useState(null);
+    const [dragX, setDragX] = useState(false);
+    const [dragY, setDragY] = useState(false);
+    const [dragPos, setDragPos] = useState(false);
 
-  const RATIO_X = image.width / renderOptions.width;
-  const RATIO_Y = image.height / renderOptions.height;
+    const RATIO_X = image.width / renderOptions.width;
+    const RATIO_Y = image.height / renderOptions.height;
 
-  /**
-   * @type {number}
-   */
-  const updatedWidth = useMemo(() => {
-    if (ellipse) {
-      return ellWidth
-        ? (pos ? pos.cx - ellipse.cx : 0) + ellWidth
-        : (pos ? pos.cx : ellipse.cx) + ellipse.rx;
-    }
-    setPos(null);
-    setEllWidth(null);
-    return 0;
-  }, [ellipse, pos, ellWidth]);
-
-  /**
-   * @type {number}
-   */
-  const updatedHeight = useMemo(() => {
-    if (ellipse) {
-      return ellHeight
-        ? (pos ? pos.cy - ellipse.cy : 0) + ellHeight
-        : (pos ? pos.cy : ellipse.cy) - ellipse.ry;
-    }
-    setPos(null);
-    setEllHeight(null);
-    return 0;
-  }, [ellipse, pos, ellHeight]);
-
-  const handleMouseUp = useCallback(() => {
-    setDragX(false);
-    setDragY(false);
-    setDragPos(false);
-  }, []);
-
-  const handleDrag = useCallback((e) => {
-    const x = Platform.OS === 'web' ? e.nativeEvent.layerX : e.nativeEvent.locationX;
-    const y = Platform.OS === 'web' ? e.nativeEvent.layerY : e.nativeEvent.locationY;
-
-    if (dragX) {
-      setEllWidth(x * RATIO_X);
-    }
-
-    if (dragY) {
-      setEllHeight(y * RATIO_Y);
-    }
-
-    if (dragPos) {
-      setPos({
-        cx: x * RATIO_X,
-        cy: y * RATIO_Y,
-      });
-    }
-  }, [dragX, dragY, dragPos, RATIO_X, RATIO_Y]);
-
-  const handleAddPoint = useCallback((event) => {
-    if (!isPointAdded) {
-      const ratioX = image.width / renderOptions.width;
-      const ratioY = image.height / renderOptions.height;
-      let cx; let
-        cy;
-      if (Platform.OS === 'web') {
-        cx = event.nativeEvent.layerX * ratioX;
-        cy = event.nativeEvent.layerY * ratioY;
-      } else {
-        cx = event.nativeEvent.locationX * ratioX;
-        cy = event.nativeEvent.locationY * ratioY;
+    /**
+     * @type {number}
+     */
+    const updatedWidth = useMemo(() => {
+      if (ellipse) {
+        return ellWidth
+          ? (pos ? pos.cx - ellipse.cx : 0) + ellWidth
+          : (pos ? pos.cx : ellipse.cx) + ellipse.rx;
       }
-      const { rx, ry } = renderOptions.ellipse;
-      const newEllipse = { cx, cy, rx: rx ?? 100, ry: ry ?? 100 };
-      setIsPointAdded(true);
-      setEllipse(newEllipse);
-    }
-  }, [isPointAdded, image.width, image.height, renderOptions]);
-
-  const handlePinchGesture = useCallback((nativeEvent) => {
-    const { scale } = nativeEvent;
-    if (ellipse) {
-      setEllWidth(ellipse.rx / scale);
-      setEllHeight(ellipse.ry / scale);
-    }
-  }, [ellipse]);
-
-  const createDamageView = useCallback(async (damageType, partType) => {
-    if (((!pos?.cx || !pos?.cy) && (!ellipse?.cx || !ellipse?.cy))
-    && ((!ellHeight || !ellWidth) && (!ellipse?.rx || !ellipse?.ry))) {
-      throw new Error(`${pos?.cx && ellipse?.cx ? '' : 'cx'}, ${pos?.cy && ellipse?.cy ? '' : 'cy'}, ${ellHeight ? '' : 'ry'}, ${ellWidth ? '' : 'rx'} is/are null`);
-    }
-
-    const rx = Math.abs(ellWidth - ellipse.cx);
-    const ry = Math.abs(ellHeight - ellipse.cy);
-
-    const viewCreateProp = {
-      imageId: image.id,
-      boundingBox: {
-        xmin: (pos?.cx ?? ellipse.cy) - rx,
-        ymin: (pos?.cy ?? ellipse.cy) - ry,
-        width: rx * 2,
-        height: ry * 2,
-      },
-    };
-
-    const newDamage = await monk.entity.damage.createOne(inspectionId, { damageType, partType });
-
-    viewCreateProp.damageId = newDamage.id;
-
-    return monk.entity.view.createOne(inspectionId, viewCreateProp);
-  }, [pos, ellHeight, ellWidth, ellipse, image?.id, inspectionId]);
-
-  useImperativeHandle(ref, () => ({
-    createDamageView,
-    reset: () => {
-      setIsPointAdded(false);
-      setEllipse(null);
-      setEllWidth(null);
-      setEllHeight(null);
       setPos(null);
-      setDragX(null);
-      setDragY(null);
-      setDragPos(null);
-    },
-  }));
+      setEllWidth(null);
+      return 0;
+    }, [ellipse, pos, ellWidth]);
 
-  const polygon = useMemo(() => (
-    ellipse && (
+    /**
+     * @type {number}
+     */
+    const updatedHeight = useMemo(() => {
+      if (ellipse) {
+        return ellHeight
+          ? (pos ? pos.cy - ellipse.cy : 0) + ellHeight
+          : (pos ? pos.cy : ellipse.cy) - ellipse.ry;
+      }
+      setPos(null);
+      setEllHeight(null);
+      return 0;
+    }, [ellipse, pos, ellHeight]);
+
+    const handleMouseUp = useCallback(() => {
+      setDragX(false);
+      setDragY(false);
+      setDragPos(false);
+    }, []);
+
+    const handleDrag = useCallback(
+      (e) => {
+        const x = Platform.OS === 'web' ? e.nativeEvent.layerX : e.nativeEvent.locationX;
+        const y = Platform.OS === 'web' ? e.nativeEvent.layerY : e.nativeEvent.locationY;
+
+        if (dragX) {
+          setEllWidth(x * RATIO_X);
+        }
+
+        if (dragY) {
+          setEllHeight(y * RATIO_Y);
+        }
+
+        if (dragPos) {
+          setPos({
+            cx: x * RATIO_X,
+            cy: y * RATIO_Y,
+          });
+        }
+      },
+      [dragX, dragY, dragPos, RATIO_X, RATIO_Y],
+    );
+
+    const handleAddPoint = useCallback(
+      (event) => {
+        if (!isPointAdded) {
+          const ratioX = image.width / renderOptions.width;
+          const ratioY = image.height / renderOptions.height;
+          let cx;
+          let cy;
+          if (Platform.OS === 'web') {
+            cx = event.nativeEvent.layerX * ratioX;
+            cy = event.nativeEvent.layerY * ratioY;
+          } else {
+            cx = event.nativeEvent.locationX * ratioX;
+            cy = event.nativeEvent.locationY * ratioY;
+          }
+          const { rx, ry } = renderOptions.ellipse;
+          const newEllipse = { cx, cy, rx: rx ?? 100, ry: ry ?? 100 };
+          setIsPointAdded(true);
+          setEllipse(newEllipse);
+        }
+      },
+      [isPointAdded, image.width, image.height, renderOptions],
+    );
+
+    const handlePinchGesture = useCallback(
+      (nativeEvent) => {
+        const { scale } = nativeEvent;
+        if (ellipse) {
+          setEllWidth(ellipse.rx / scale);
+          setEllHeight(ellipse.ry / scale);
+        }
+      },
+      [ellipse],
+    );
+
+    const createDamageView = useCallback(
+      async ({ damageType, partType, additionalData }) => {
+        if (
+          (!pos?.cx || !pos?.cy)
+          && (!ellipse?.cx || !ellipse?.cy)
+          && (!ellHeight || !ellWidth)
+          && (!ellipse?.rx || !ellipse?.ry)
+        ) {
+          throw new Error(
+            `${pos?.cx && ellipse?.cx ? '' : 'cx'}, ${pos?.cy && ellipse?.cy ? '' : 'cy'}, ${
+              ellHeight ? '' : 'ry'
+            }, ${ellWidth ? '' : 'rx'} is/are null`,
+          );
+        }
+
+        const rx = Math.abs(ellWidth - ellipse.cx);
+        const ry = Math.abs(ellHeight - ellipse.cy);
+
+        const viewCreateProp = {
+          boundingBox: {
+            xmin: (pos?.cx ?? ellipse.cy) - rx,
+            ymin: (pos?.cy ?? ellipse.cy) - ry,
+            width: rx * 2,
+            height: ry * 2,
+          },
+        };
+
+        const newDamage = await monk.entity.damage.createOne(inspectionId, {
+          damageType,
+          partType,
+        });
+
+        viewCreateProp.damageId = newDamage.id;
+
+        if (image.id) {
+          viewCreateProp.imageId = image.id;
+
+          return monk.entity.view.createOne(inspectionId, viewCreateProp);
+        }
+
+        const fileType = Platform.OS === 'web' ? 'webp' : 'jpg';
+        const filename = `${image.id}-${inspectionId}.${fileType}`;
+        const multiPartKeys = {
+          image: 'image',
+          json: 'json',
+          filename,
+          type: `image/${fileType}`,
+        };
+
+        const json = JSON.stringify({
+          acquisition: {
+            strategy: 'upload_multipart_form_keys',
+            file_key: multiPartKeys.image,
+          },
+          additional_data: {
+            ...additionalData,
+            createdAt: new Date(),
+          },
+        });
+
+        let fileBits;
+
+        if (Platform.OS === 'web') {
+          const res = await axios.get(image.source.uri, { responseType: 'blob' });
+          const file = res.data;
+
+          fileBits = [file];
+        } else {
+          const buffer = Buffer.from(image.source.uri, 'base64');
+          fileBits = new Blob([buffer], { type: 'png' });
+        }
+
+        const file = new File(fileBits, multiPartKeys.filename, {
+          type: multiPartKeys.type,
+        });
+
+        const data = new FormData();
+        data.append(multiPartKeys.json, json);
+        data.append(multiPartKeys.image, file);
+
+        return monk.entity.view.createOne(inspectionId, { ...viewCreateProp, newImage: data });
+      },
+      [pos, ellHeight, ellWidth, ellipse, image?.id, inspectionId],
+    );
+
+    useImperativeHandle(ref, () => ({
+      createDamageView,
+      reset: () => {
+        setIsPointAdded(false);
+        setEllipse(null);
+        setEllWidth(null);
+        setEllHeight(null);
+        setPos(null);
+        setDragX(null);
+        setDragY(null);
+        setDragPos(null);
+      },
+    }));
+
+    const polygon = useMemo(
+      () => ellipse && (
       <Ellipse
         cx={pos ? pos.cx : ellipse.cx}
         cy={pos ? pos.cy : ellipse.cy}
@@ -173,16 +237,18 @@ const DamageAnnotations = forwardRef(({
         ry={ellHeight ? Math.abs(ellHeight - ellipse.cy) : ellipse.ry}
         stroke={options?.ellipse?.stroke?.color ?? DEFAULT_OPTIONS.ellipse.stroke.color}
         fillOpacity={0} // On the web, by default it is fill in black
-        strokeWidth={options?.ellipse?.stroke?.strokeWidth
-          ?? DEFAULT_OPTIONS.ellipse.stroke.strokeWidth}
+        strokeWidth={
+              options?.ellipse?.stroke?.strokeWidth ?? DEFAULT_OPTIONS.ellipse.stroke.strokeWidth
+            }
         onMouseDown={() => setDragPos(true)}
         onPressIn={() => setDragPos(true)}
       />
-    )
-  ), [options.ellipse.stroke, pos, ellipse, ellWidth, ellHeight]);
+      ),
+      [options.ellipse.stroke, pos, ellipse, ellWidth, ellHeight],
+    );
 
-  const anchor = useMemo(() => (
-    ellipse && (
+    const anchor = useMemo(
+      () => ellipse && (
       <>
         <Circle
           r={options?.ellipse?.anchor?.y?.radius ?? DEFAULT_OPTIONS.ellipse.anchor.y.radius}
@@ -209,48 +275,51 @@ const DamageAnnotations = forwardRef(({
           onPressIn={() => setDragPos(true)}
         />
       </>
-    )), [ellipse, options.ellipse.anchor, pos, updatedHeight, updatedWidth]);
-
-  if (!ellipse) {
-    return (
-      <Svg
-        viewBox={`0 0 ${image.width} ${image.height}`}
-        onPress={handleAddPoint}
-        onClick={handleAddPoint}
-        {...renderOptions}
-      >
-        <DamageImage name={image.id} source={image.source} />
-      </Svg>
+      ),
+      [ellipse, options.ellipse.anchor, pos, updatedHeight, updatedWidth],
     );
-  }
 
-  return (
-    <PinchGestureHandler onGestureEvent={(p) => handlePinchGesture(p.nativeEvent)}>
-      <Svg
-        viewBox={`0 0 ${image.width} ${image.height}`}
-        onMouseMove={handleDrag}
-        onTouchMove={handleDrag}
-        onMouseUp={handleMouseUp}
-        onTouchEnd={handleMouseUp}
-        {...renderOptions}
-      >
-        <Defs>
-          <ClipPath id={`clip${image.id}`}>{polygon}</ClipPath>
-        </Defs>
-        {/* Show background image with a low opacity */}
-        <DamageImage
-          name={image.id}
-          source={image.source}
-          opacity={options?.backgroundOpacity ?? DEFAULT_OPTIONS.backgroundOpacity}
-        />
-        {/* Show Damages Polygon */}
-        <DamageImage name={image.id} source={image.source} clip={clip} />
-        {polygon}
-        {anchor}
-      </Svg>
-    </PinchGestureHandler>
-  );
-});
+    if (!ellipse) {
+      return (
+        <Svg
+          viewBox={`0 0 ${image.width} ${image.height}`}
+          onPress={handleAddPoint}
+          onClick={handleAddPoint}
+          {...renderOptions}
+        >
+          <DamageImage name={image.id} source={image.source} />
+        </Svg>
+      );
+    }
+
+    return (
+      <PinchGestureHandler onGestureEvent={(p) => handlePinchGesture(p.nativeEvent)}>
+        <Svg
+          viewBox={`0 0 ${image.width} ${image.height}`}
+          onMouseMove={handleDrag}
+          onTouchMove={handleDrag}
+          onMouseUp={handleMouseUp}
+          onTouchEnd={handleMouseUp}
+          {...renderOptions}
+        >
+          <Defs>
+            <ClipPath id={`clip${image.id}`}>{polygon}</ClipPath>
+          </Defs>
+          {/* Show background image with a low opacity */}
+          <DamageImage
+            name={image.id}
+            source={image.source}
+            opacity={options?.backgroundOpacity ?? DEFAULT_OPTIONS.backgroundOpacity}
+          />
+          {/* Show Damages Polygon */}
+          <DamageImage name={image.id} source={image.source} clip={clip} />
+          {polygon}
+          {anchor}
+        </Svg>
+      </PinchGestureHandler>
+    );
+  },
+);
 
 export default DamageAnnotations;
 

--- a/packages/visualization/src/components/DamageHighlight/index.js
+++ b/packages/visualization/src/components/DamageHighlight/index.js
@@ -1,246 +1,109 @@
-import React, { forwardRef, useCallback, useImperativeHandle, useState } from 'react';
+import React, { useMemo, forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import isEmpty from 'lodash.isempty';
-import { ClipPath, Defs, Ellipse, Polygon, Svg, Text } from 'react-native-svg';
-import { Platform } from 'react-native';
-import DamageImage from '../DamageImage';
-import useSvgToImage from '../../hooks/useSvgToImage';
 
-export const DEFAULT_OPTIONS = {
-  background: {
-    opacity: 1,
-  },
-  label: {
-    fontSize: 5,
-  },
-  polygons: {
-    opacity: 1,
-    stroke: {
-      color: 'yellow',
-      strokeWidth: 2.5,
-    },
-  },
-  ellipses: {
-    opacity: 1,
-    stroke: {
-      color: 'yellow',
-      strokeWidth: 2.5,
-    },
-  },
-};
+import ElementHighlight from '../ElementHighlight';
 
 const DamageHighlight = forwardRef(({
-  damages,
   image,
+  damages,
+  damageStyle,
   options,
   onPressDamage,
   ...passThroughProps
 }, ref) => {
-  const [svgRef, setSvgRef] = useState(null);
-  const toImage = useSvgToImage();
-  const completedOptions = { ...DEFAULT_OPTIONS, ...options };
+  /**
+   * Filter all views from vehicle parts, showing only damages
+   */
+  const imageViewDamage = useMemo(() => image.views
+    ?.filter((view) => damages.some(({ id }) => view.elementId === id)), [image, damages]);
 
-  const measureText = useCallback((str, fontSize) => {
-    // eslint-disable-next-line max-len
-    const widths = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.2796875, 0.2765625, 0.3546875, 0.5546875, 0.5546875, 0.8890625, 0.665625, 0.190625, 0.3328125, 0.3328125, 0.3890625, 0.5828125, 0.2765625, 0.3328125, 0.2765625, 0.3015625, 0.5546875, 0.5546875, 0.5546875, 0.5546875, 0.5546875, 0.5546875, 0.5546875, 0.5546875, 0.5546875, 0.5546875, 0.2765625, 0.2765625, 0.584375, 0.5828125, 0.584375, 0.5546875, 1.0140625, 0.665625, 0.665625, 0.721875, 0.721875, 0.665625, 0.609375, 0.7765625, 0.721875, 0.2765625, 0.5, 0.665625, 0.5546875, 0.8328125, 0.721875, 0.7765625, 0.665625, 0.7765625, 0.721875, 0.665625, 0.609375, 0.721875, 0.665625, 0.94375, 0.665625, 0.665625, 0.609375, 0.2765625, 0.3546875, 0.2765625, 0.4765625, 0.5546875, 0.3328125, 0.5546875, 0.5546875, 0.5, 0.5546875, 0.5546875, 0.2765625, 0.5546875, 0.5546875, 0.221875, 0.240625, 0.5, 0.221875, 0.8328125, 0.5546875, 0.5546875, 0.5546875, 0.5546875, 0.3328125, 0.5, 0.2765625, 0.5546875, 0.5, 0.721875, 0.5, 0.5, 0.5, 0.3546875, 0.259375, 0.353125, 0.5890625];
-    const avg = 0.5279276315789471;
-    return str
-      .split('')
-      .map((c) => (c.charCodeAt(0) < widths.length ? widths[c.charCodeAt(0)] : avg))
-      .reduce((cur, acc) => acc + cur) * fontSize;
-  }, []);
+  const userDamagesViews = useMemo(() => imageViewDamage?.filter((view) => view.createdBy !== 'algo'), [imageViewDamage]);
+  const aiDamagesViews = useMemo(() => imageViewDamage?.filter((view) => view.createdBy === 'algo'), [imageViewDamage]);
 
-  const handlePress = useCallback((damage) => {
-    if (onPressDamage && (typeof onPressDamage === 'function')) { onPressDamage(damage); }
-  }, [onPressDamage]);
+  const elementImage = useMemo(() => ({
+    height: image.imageHeight,
+    width: image.imageWidth,
+    source: { uri: image.path },
+    id: image.id,
+  }), [image]);
 
-  const checkCollisions = (lb1, lb2) => {
-    if (lb1.x + lb1.width >= lb2.x
-      && lb1.x + lb1.width <= lb2.x + lb2.width
-      && lb1.y + lb1.height >= lb2.y
-      && lb1.y + lb1.height <= lb2.y + lb2.height) {
-      return true;
-    }
+  const damageElements = useMemo(() => {
+    if (!userDamagesViews || !aiDamagesViews) { return null; }
 
-    return (lb1.x >= lb2.x
-      && lb1.x <= lb2.x + lb2.width
-      && lb1.y >= lb2.y
-      && lb1.y <= lb2.y + lb2.height);
-  };
+    const aiDamages = aiDamagesViews.map((view) => {
+      const damage = damages.find(({ id }) => id === view.elementId);
 
-  const renderDamages = useCallback(() => {
-    const damageFigures = [];
-    const labels = [];
-    const polygonsLabel = [];
-
-    damages.forEach((damage) => {
-      const { ellipse, id, damageType, polygons } = damage;
-      const { ellipses: ellipsesStyle, polygons: polygonsStyle, label } = completedOptions;
-
-      const strokeType = (polygons ? polygonsStyle : ellipsesStyle);
-
-      const strokes = {
-        stroke: strokeType.stroke.color,
-        // strokeDasharray: damageType === 'dent' ? '5, 5' : '',
-        strokeWidth: strokeType.stroke.strokeWidth,
+      return {
+        elementStyle: damageStyle(damage),
+        elementType: damage?.damageType,
+        id: view.id,
+        polygons: view.imageRegion.specification.polygons,
       };
+    });
+    const userDamages = userDamagesViews.map((view) => {
+      const { xmin, ymin, width, height } = view.imageRegion.specification.boundingBox;
+      const rx = width * 0.5;
+      const ry = height * 0.5;
+      const damage = damages.find(({ id }) => id === view.elementId);
 
-      const boundingBox = {
-        xMin: !polygons ? (ellipse.cx - ellipse.rx) : polygons.reduce((xMinPolygon, p) => (
-          Math.min(p.reduce((xMin, points) => (
-            Math.min(points[0], xMin)
-          ), Number.MAX_VALUE), xMinPolygon)), Number.MAX_VALUE),
-        yMin: !polygons ? (ellipse.cy - ellipse.ry) : polygons.reduce((yMinPolygon, p) => (
-          Math.min(p.reduce((yMin, points) => (
-            Math.min(points[1], yMin)
-          ), Number.MAX_VALUE), yMinPolygon)), Number.MAX_VALUE),
-        yMax: !polygons ? (ellipse.cy - ellipse.ry) : polygons.reduce((yMaxPolygon, p) => (
-          Math.max(p.reduce((yMax, points) => (
-            Math.max(points[1], yMax)
-          ), 0), yMaxPolygon)), 0),
+      return {
+        elementStyle: damageStyle(damage),
+        elementType: damages.find(({ id }) => id === view.elementId)?.damageType,
+        id: view.id,
+        ellipses: ({ cx: xmin + rx, cy: ymin + ry, rx, ry }),
       };
-
-      if (damageType) {
-        const labelPosition = {
-          x: boundingBox.xMin,
-          y: ((boundingBox.yMin - label.fontSize) <= 0
-            ? boundingBox.yMax
-            : boundingBox.yMin) - label.fontSize / 2,
-          textAnchor:
-            (boundingBox.xMin + measureText(damageType, label.fontSize)) >= image.width
-              ? 'end'
-              : 'start',
-        };
-
-        const labelInfo = {
-          ...labelPosition,
-          width: measureText(damageType, label.fontSize),
-          height: label.fontSize,
-          damageType,
-          color: label.color,
-        };
-
-        const collision = polygonsLabel.filter((lb) => checkCollisions(labelInfo, lb));
-
-        const t = (collision
-          .map((c) => c.damageType === damageType)
-          .reduce((prev, curr) => prev || curr, false)) === false;
-
-        if ((collision.length <= 0) || t) {
-          while (polygonsLabel.filter((lb) => checkCollisions(labelInfo, lb)).length > 0) {
-            labelPosition.y -= label.fontSize;
-            labelInfo.y -= label.fontSize;
-          }
-          polygonsLabel.push(labelInfo);
-
-          labels.push(
-            <Text
-              paintOrder="stroke"
-              stroke={label.color}
-              strokeWidth={5}
-              fill="white"
-              fontSize={label.fontSize}
-              {...labelPosition}
-            >
-              {`${damageType.charAt(0)
-                .toUpperCase() + damageType.slice(1)
-                .replaceAll('_', ' ')}`}
-            </Text>,
-          );
-        }
-      }
-
-      if (polygons) {
-        polygons.forEach((p, index) => {
-          damageFigures.push(
-            <Polygon
-              {...strokes}
-              key={`image-${image.id}-polygon-${id}-${String(index)}`}
-              fillOpacity={0}
-              points={p.map((card) => `${card[0]},${card[1]}`).join(' ')}
-              onClick={() => handlePress(damage)}
-              onPress={() => handlePress(damage)}
-              {...damage.damageStyle ?? {}}
-            />,
-          );
-        });
-      }
-
-      if (ellipse) {
-        damageFigures.push(<Ellipse
-          {...ellipse}
-          {...strokes}
-          key={`image-${image.id}-damage-${damage.id}-ellipse`}
-          fillOpacity={0}
-          onClick={() => handlePress(damage)}
-          onPress={() => handlePress(damage)}
-          {...damage.damageStyle ?? {}}
-        />);
-      }
     });
 
-    return [damageFigures, labels];
-  }, [damages, image.id, image.width, measureText, completedOptions]);
+    return [...aiDamages, ...userDamages];
+  }, [userDamagesViews, aiDamagesViews]);
 
-  const [Polygons, Labels] = renderDamages();
-
-  useImperativeHandle(ref, () => ({
-    toImage: () => (
-      Platform.OS === 'native'
-        ? toImage(svgRef, image.width, image.height)
-        : toImage(image)),
-  }));
+  if (!damageElements) { return null; }
 
   return (
-    <Svg
-      id={`svg-${image.id}`}
-      ref={(rf) => setSvgRef(rf)}
-      xmlns="http://www.w3.org/2000/svg"
-      xmlnsXlink="http://www.w3.org/1999/xlink"
-      viewBox={`0 0 ${image.width} ${image.height}`}
+    <ElementHighlight
+      image={elementImage}
+      elements={damageElements}
+      onPressElement={onPressDamage}
+      options={options}
+      ref={ref}
       {...passThroughProps}
-    >
-      <Defs>
-        <ClipPath id={`clip${image.id}`}>{Polygons}</ClipPath>
-      </Defs>
-      {/* Show background image with a low opacity */}
-      <DamageImage
-        name={image.id}
-        source={image.source}
-        opacity={isEmpty(Polygons) ? 1 : completedOptions.background.opacity}
-      />
-      {Labels}
-      <DamageImage
-        name={image.id}
-        source={image.source}
-        clip
-        opacity={completedOptions.polygons.opacity}
-      />
-      {Polygons}
-    </Svg>
+    />
   );
 });
 
 DamageHighlight.propTypes = {
   damages: PropTypes.arrayOf(PropTypes.shape({
-    damageStyle: PropTypes.any,
+    createdBy: PropTypes.string,
     damageType: PropTypes.string,
-    ellipse: PropTypes.shape({
-      cx: PropTypes.number,
-      cy: PropTypes.number,
-      rx: PropTypes.number,
-      ry: PropTypes.number,
-    }),
-    id: PropTypes.string.isRequired,
-    polygons: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number))),
-  })),
-  image: PropTypes.shape({
-    height: PropTypes.number,
+    deletedAt: PropTypes.string,
     id: PropTypes.string,
-    source: PropTypes.shape({
-      uri: PropTypes.string,
-    }),
-    width: PropTypes.number,
+    inspectionId: PropTypes.string,
+  })),
+  damageStyle: PropTypes.func,
+  image: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    imageHeight: PropTypes.number.isRequired,
+    imageWidth: PropTypes.number.isRequired,
+    mimeType: PropTypes.string,
+    path: PropTypes.string,
+    views: PropTypes.arrayOf(PropTypes.shape({
+      createdBy: PropTypes.string,
+      elementId: PropTypes.string,
+      id: PropTypes.string,
+      imageRegion: PropTypes.shape({
+        id: PropTypes.string,
+        imageId: PropTypes.string,
+        specification: PropTypes.shape({
+          boundingBox: PropTypes.shape({
+            height: PropTypes.number,
+            width: PropTypes.number,
+            xmin: PropTypes.number,
+            ymin: PropTypes.number,
+          }).isRequired,
+          polygons: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number))),
+        }),
+      }),
+    })),
   }).isRequired,
   onPressDamage: PropTypes.func,
   options: PropTypes.shape({
@@ -269,8 +132,9 @@ DamageHighlight.propTypes = {
 
 DamageHighlight.defaultProps = {
   damages: [],
-  options: DEFAULT_OPTIONS,
-  onPressDamage: null,
+  damageStyle: () => {},
+  onPressDamage: () => null,
+  options: {},
 };
 
 export default DamageHighlight;

--- a/packages/visualization/src/components/DamageHighlight/index.js
+++ b/packages/visualization/src/components/DamageHighlight/index.js
@@ -50,7 +50,7 @@ const DamageHighlight = forwardRef(({
         elementStyle: damageStyle(damage),
         elementType: damages.find(({ id }) => id === view.elementId)?.damageType,
         id: view.id,
-        ellipses: ({ cx: xmin + rx, cy: ymin + ry, rx, ry }),
+        ellipse: ({ cx: xmin + rx, cy: ymin + ry, rx, ry }),
       };
     });
 

--- a/packages/visualization/src/components/ElementHighlight/index.js
+++ b/packages/visualization/src/components/ElementHighlight/index.js
@@ -45,7 +45,7 @@ const ElementHighlight = forwardRef(({
     const labels = [];
 
     elements.forEach((element) => {
-      const { ellipses, id, polygons } = element;
+      const { ellipse, id, polygons } = element;
       const { ellipses: ellipsesStyle, polygons: polygonsStyle } = completedOptions;
 
       const strokeType = (polygons ? polygonsStyle : ellipsesStyle);
@@ -76,17 +76,15 @@ const ElementHighlight = forwardRef(({
         });
       }
 
-      if (ellipses && ellipses.length > 0) {
-        ellipses.forEach((ellipse) => {
-          damageFigures.push(<Ellipse
-            {...ellipse}
-            {...strokes}
-            {...onPressEvent}
-            key={`image-${image.id}-damage-${element.id}-ellipse`}
-            fillOpacity={0}
-            {...element.damageStyle ?? {}}
-          />);
-        });
+      if (ellipse) {
+        damageFigures.push(<Ellipse
+          {...ellipse}
+          {...strokes}
+          {...onPressEvent}
+          key={`image-${image.id}-damage-${element.id}-ellipse`}
+          fillOpacity={0}
+          {...element.damageStyle ?? {}}
+        />);
       }
     });
 
@@ -140,12 +138,12 @@ ElementHighlight.propTypes = {
       strokeWidth: PropTypes.number,
     }),
     elementType: PropTypes.string,
-    ellipses: PropTypes.arrayOf(PropTypes.shape({
+    ellipse: PropTypes.shape({
       cx: PropTypes.number,
       cy: PropTypes.number,
       rx: PropTypes.number,
       ry: PropTypes.number,
-    })),
+    }),
     id: PropTypes.string.isRequired,
     polygons: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number))),
   })),

--- a/packages/visualization/src/components/ElementHighlight/index.js
+++ b/packages/visualization/src/components/ElementHighlight/index.js
@@ -1,0 +1,191 @@
+import React, { forwardRef, useCallback, useImperativeHandle, useState } from 'react';
+import PropTypes from 'prop-types';
+import isEmpty from 'lodash.isempty';
+import { ClipPath, Defs, Ellipse, Polygon, Svg } from 'react-native-svg';
+import { Platform } from 'react-native';
+import DamageImage from '../DamageImage';
+import useSvgToImage from '../../hooks/useSvgToImage';
+
+export const DEFAULT_OPTIONS = {
+  background: {
+    opacity: 1,
+  },
+  label: {
+    fontSize: 5,
+  },
+  polygons: {
+    opacity: 1,
+    stroke: {
+      color: 'yellow',
+      strokeWidth: 2.5,
+    },
+  },
+  ellipses: {
+    opacity: 1,
+    stroke: {
+      color: 'yellow',
+      strokeWidth: 2.5,
+    },
+  },
+};
+
+const ElementHighlight = forwardRef(({
+  elements,
+  image,
+  options,
+  onPressElement,
+  ...passThroughProps
+}, ref) => {
+  const [svgRef, setSvgRef] = useState(null);
+  const toImage = useSvgToImage();
+  const completedOptions = { ...DEFAULT_OPTIONS, ...options };
+
+  const renderDamages = useCallback(() => {
+    const damageFigures = [];
+    const labels = [];
+
+    elements.forEach((element) => {
+      const { ellipses, id, polygons } = element;
+      const { ellipses: ellipsesStyle, polygons: polygonsStyle } = completedOptions;
+
+      const strokeType = (polygons ? polygonsStyle : ellipsesStyle);
+
+      const strokes = {
+        stroke: strokeType.stroke.color,
+        // strokeDasharray: damageType === 'dent' ? '5, 5' : '',
+        strokeWidth: strokeType.stroke.strokeWidth,
+      };
+
+      const onPressEvent = Platform.select({
+        web: { onClick: () => onPressElement(element) },
+        native: { onPress: () => onPressElement(element) },
+      });
+
+      if (polygons && polygons.length > 0) {
+        polygons.forEach((p, index) => {
+          damageFigures.push(
+            <Polygon
+              {...strokes}
+              {...onPressEvent}
+              key={`image-${image.id}-polygon-${id}-${String(index)}`}
+              fillOpacity={0}
+              points={p.map((card) => `${card[0]},${card[1]}`).join(' ')}
+              {...element.elementStyle ?? {}}
+            />,
+          );
+        });
+      }
+
+      if (ellipses && ellipses.length > 0) {
+        ellipses.forEach((ellipse) => {
+          damageFigures.push(<Ellipse
+            {...ellipse}
+            {...strokes}
+            {...onPressEvent}
+            key={`image-${image.id}-damage-${element.id}-ellipse`}
+            fillOpacity={0}
+            {...element.damageStyle ?? {}}
+          />);
+        });
+      }
+    });
+
+    return [damageFigures, labels];
+  }, [elements, image.id, image.width, completedOptions]);
+
+  const [Polygons, Labels] = renderDamages();
+
+  useImperativeHandle(ref, () => ({
+    toImage: () => (
+      Platform.OS === 'native'
+        ? toImage(svgRef, image.width, image.height)
+        : toImage(image)),
+  }));
+
+  return (
+    <Svg
+      id={`svg-${image.id}`}
+      ref={(rf) => setSvgRef(rf)}
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox={`0 0 ${image.width} ${image.height}`}
+      {...passThroughProps}
+    >
+      <Defs>
+        <ClipPath id={`clip${image.id}`}>{Polygons}</ClipPath>
+      </Defs>
+      {/* Show background image with a low opacity */}
+      <DamageImage
+        name={image.id}
+        source={image.source}
+        opacity={isEmpty(Polygons) ? 1 : completedOptions.background.opacity}
+      />
+      {Labels}
+      <DamageImage
+        name={image.id}
+        source={image.source}
+        clip
+        opacity={completedOptions.polygons.opacity}
+      />
+      {Polygons}
+    </Svg>
+  );
+});
+
+ElementHighlight.propTypes = {
+  elements: PropTypes.arrayOf(PropTypes.shape({
+    elementStyle: PropTypes.shape({
+      stroke: PropTypes.string,
+      strokeDasharray: PropTypes.string,
+      strokeWidth: PropTypes.number,
+    }),
+    elementType: PropTypes.string,
+    ellipses: PropTypes.arrayOf(PropTypes.shape({
+      cx: PropTypes.number,
+      cy: PropTypes.number,
+      rx: PropTypes.number,
+      ry: PropTypes.number,
+    })),
+    id: PropTypes.string.isRequired,
+    polygons: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number))),
+  })),
+  image: PropTypes.shape({
+    height: PropTypes.number,
+    id: PropTypes.string,
+    source: PropTypes.shape({
+      uri: PropTypes.string,
+    }),
+    width: PropTypes.number,
+  }).isRequired,
+  onPressElement: PropTypes.func,
+  options: PropTypes.shape({
+    background: PropTypes.shape({
+      opacity: PropTypes.number,
+    }),
+    ellipses: PropTypes.shape({
+      opacity: PropTypes.number,
+      stroke: PropTypes.shape({
+        color: PropTypes.string,
+        strokeWidth: PropTypes.number,
+      }),
+    }),
+    label: PropTypes.shape({
+      fontSize: PropTypes.number,
+    }),
+    polygons: PropTypes.shape({
+      opacity: PropTypes.number,
+      stroke: PropTypes.shape({
+        color: PropTypes.string,
+        strokeWidth: PropTypes.number,
+      }),
+    }),
+  }),
+};
+
+ElementHighlight.defaultProps = {
+  elements: [],
+  options: DEFAULT_OPTIONS,
+  onPressElement: () => null,
+};
+
+export default ElementHighlight;

--- a/services/inspection-report/src/views/InspectionDetails/ImageList/index.js
+++ b/services/inspection-report/src/views/InspectionDetails/ImageList/index.js
@@ -10,6 +10,8 @@ import MUIImageList from '@mui/material/ImageList';
 import ImageListItem from '@mui/material/ImageListItem';
 import ImageListItemBar from '@mui/material/ImageListItemBar';
 
+import { DamageHighlight } from '@monkvision/visualization';
+
 import { Menu } from 'components';
 
 export default function ImageList({ itemData }) {
@@ -24,7 +26,7 @@ export default function ImageList({ itemData }) {
 
   // the selected wheel analysis if present
   const selectedWheelAnalysis = useMemo(
-    () => itemData.find((item) => item.id === imageId)?.wheelAnalysis,
+    () => itemData.images?.find((item) => item.id === imageId)?.wheelAnalysis,
     [itemData, imageId],
   );
 
@@ -43,29 +45,15 @@ export default function ImageList({ itemData }) {
         open={!!anchorEl}
       />
       <MUIImageList>
-        {itemData.map((item) =>
-        // const polygonsProps = item?.damages?.length > 0 ? { damages:
-        //     item.damages.map(({ imageRegion, damageType, elementId }) => (
-        //       { damageType, polygons: imageRegion.specification.polygons, id: elementId }
-        //     )) } : {};
-
-          // eslint-disable-next-line implicit-arrow-linebreak
+        {itemData.images.map((item, i) =>
           (item ? (
-            <ImageListItem key={item.path}>
-              {/* <DamageHighlight */}
-              {/*  image={{ */}
-              {/*    height: item.imageHeight, */}
-              {/*    width: item.imageWidth, */}
-              {/*    source: { uri: item.path }, */}
-              {/*    id: item.id, */}
-              {/*  }} */}
-              {/*  // options={{ */}
-              {/*  //   label: { */}
-              {/*  //     fontSize: 12, */}
-              {/*  //   }, */}
-              {/*  // }} */}
-              {/*  {...polygonsProps} */}
-              {/* /> */}
+            <ImageListItem key={`${item.path}-${i}`}>
+              {/* <DamageHighlight
+                damages={itemData.damages}
+                damageStyle={(damage) => (damage.damageType === 'dent' ? { stroke: 'red', strokeDasharray: '5, 5' } : {})}
+                image={item}
+                onPressDamage={(damage) => { console.log(damage); }}
+              /> */}
               <ImageListItemBar
                 title={item?.additionalData?.label?.en}
                 actionIcon={(
@@ -87,23 +75,40 @@ export default function ImageList({ itemData }) {
 }
 
 ImageList.propTypes = {
-  itemData: PropTypes.arrayOf(PropTypes.shape({
-    additionalData: PropTypes.shape({
-      label: PropTypes.objectOf(PropTypes.string).isRequired,
-    }),
-    damages: PropTypes.arrayOf(PropTypes.shape({
-      damageType: PropTypes.string,
-      id: PropTypes.string.isRequired,
-      imageRegion: PropTypes.shape({
-        specification: PropTypes.shape({
-          polygons: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number))),
-        }),
+  itemData: PropTypes.shape({
+    images: PropTypes.arrayOf(PropTypes.shape({
+      additionalData: PropTypes.shape({
+        label: PropTypes.objectOf(PropTypes.string).isRequired,
       }),
+      id: PropTypes.string.isRequired,
+      imageHeight: PropTypes.number.isRequired,
+      imageWidth: PropTypes.number.isRequired,
+      views: PropTypes.arrayOf(PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        imageRegion: PropTypes.shape({
+          specification: PropTypes.shape({
+            boundingBox: PropTypes.shape({
+              height: PropTypes.number,
+              width: PropTypes.number,
+              xmin: PropTypes.number,
+              ymin: PropTypes.number,
+            }).isRequired,
+            polygons: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number))),
+          }),
+        }),
+      })),
+      path: PropTypes.string.isRequired,
     })),
-    path: PropTypes.string.isRequired,
-  })),
+    damages: PropTypes.arrayOf(PropTypes.shape({
+      createdBy: PropTypes.string,
+      damageType: PropTypes.string,
+      deletedAt: PropTypes.string,
+      id: PropTypes.string,
+      inspectionId: PropTypes.string,
+    })),
+  }),
 };
 
 ImageList.defaultProps = {
-  itemData: [],
+  itemData: {},
 };

--- a/services/inspection-report/src/views/InspectionDetails/index.js
+++ b/services/inspection-report/src/views/InspectionDetails/index.js
@@ -27,11 +27,9 @@ export default function InspectionDetails() {
   } = useGetPdfReport(id);
 
   const imageItems = useMemo(() => {
-    if (!images) { return []; }
-    return images.map((image) => (
-      { ...image, damages: damages.filter(({ imageRegion }) => imageRegion.imageId === image.id) }
-    ));
-  }, [images]);
+    if (!images) { return {}; }
+    return { images, damages };
+  }, [images, damages]);
 
   const inspectionIsNotCompleted = useMemo(() => tasks.some((t) => t.status !== 'DONE'), [tasks]);
 

--- a/services/inspection-report/src/views/InspectionDetails/useGetInspection/index.js
+++ b/services/inspection-report/src/views/InspectionDetails/useGetInspection/index.js
@@ -15,21 +15,22 @@ export default function useGetInspection(inspectionId) {
   const vehicleEntities = useSelector(monk.entity.vehicle.selectors.selectEntities);
 
   const inspection = inspectionEntities[inspectionId];
-  const images = inspection
-    ? Object.values(imageEntities).filter(({ id }) => inspection?.images?.includes(id))
-    : [];
-  const tasks = inspection
-    ? Object.values(taskEntities).filter(({ id }) => inspection?.tasks?.includes(id))
-    : [];
   const views = inspection
     ? Object
       .values(viewsEntities)
       .filter(({ imageRegion }) => inspection?.images?.includes(imageRegion.imageId))
     : [];
-  const damages = views
-    ? views
-      .filter(({ elementId }) => inspection?.damages?.includes(elementId))
-      .map((view) => ({ ...view, damageType: damagesEntities[view.elementId].damageType }))
+  const images = inspection
+    ? Object
+      .values(imageEntities)
+      .filter(({ id }) => inspection?.images?.includes(id))
+      .map((image) => ({ ...image, views: image.views?.map((view) => views.find(({ id }) => id === view)) }))
+    : [];
+  const tasks = inspection
+    ? Object.values(taskEntities).filter(({ id }) => inspection?.tasks?.includes(id))
+    : [];
+  const damages = inspection
+    ? Object.values(damagesEntities).filter(({ id }) => inspection?.damages?.includes(id))
     : [];
 
   const onRequestSuccess = useCallback(({ entities, result }) => {

--- a/services/inspection-report/src/views/Inspections/index.js
+++ b/services/inspection-report/src/views/Inspections/index.js
@@ -79,12 +79,10 @@ export default function Inspections() {
   const inspections = useSelector(monk.entity.inspection.selectors.selectEntities);
 
   const makeNextRequest = () => monk.entity.inspection.getMany({
-    params: {
       limit: 20,
       inspectionStatus: 'DONE',
       showDeleted,
       ...(nextCursor !== null && { [nextCursor.param]: nextCursor.value }),
-    },
   });
 
   const makeNextRequestMemoized = useCallback(async () => makeNextRequest(), []);

--- a/website/docs/js/api/components/DamageAnnotation.md
+++ b/website/docs/js/api/components/DamageAnnotation.md
@@ -52,7 +52,7 @@ Set the clip path property to show separate the polygons of the picture.
 ``` javascript
 PropTypes.shape({
   height: PropTypes.number,
-  id: PropTypes.string, // image's uuid
+  id: PropTypes.string, // image's uuid if existant, null if a new picture
   source: PropTypes.shape({
     uri: PropTypes.string, // "https://my_image_path.monk.ai"
   }),
@@ -140,7 +140,7 @@ To use methods that `DamageHighlight` exposes one has to create a component `ref
 ## createDamageView(damageType, partType)
 `PropTypes.func`
 
-Create a damage containing a `damageType: PropTypes.string` and a `partType: PropTypes.string` then create a new view on the current image of the inspection with the bounding box calculated from the ellipse.
+Create a damage containing a `damageType: PropTypes.string` and a `partType: PropTypes.string` then create a new view on the current image (a freshly taken image or an already taken image) of the inspection with the bounding box calculated from the ellipse.
 ## reset()
 `PropTypes.func`
 

--- a/website/docs/js/api/components/DamageAnnotation.md
+++ b/website/docs/js/api/components/DamageAnnotation.md
@@ -141,6 +141,10 @@ To use methods that `DamageHighlight` exposes one has to create a component `ref
 `PropTypes.func`
 
 Create a damage containing a `damageType: PropTypes.string` and a `partType: PropTypes.string` then create a new view on the current image of the inspection with the bounding box calculated from the ellipse.
+## reset()
+`PropTypes.func`
+
+Clear the image from the created ellipse.
 
 ```js
 // ...

--- a/website/docs/js/api/components/DamageAnnotation.md
+++ b/website/docs/js/api/components/DamageAnnotation.md
@@ -29,19 +29,18 @@ const image = {
   },
 };
 
-const renderOptions = { width: 400, height: 220, rx: 100, ry: 100 };
-
-<DamageAnnotation
-  image={image}
-  renderOptions={renderOptions}
-  clip={false}
-/>;
+<DamageAnnotation image={image} />;
 ```
 
 The property `image` comes from the result of an inspection, which is formatted with the
 hooks [`usePolygon`](/docs/js/api/components/damage-highlight#usepolygons).
 
 # Props
+
+## inspectionId
+`PropsType.string`
+
+Inspection Id
 
 ## clip
 `PropsType.bool`
@@ -86,8 +85,6 @@ Set the style of the ellipse by defining the stroke's color and width
 
 Set the color of the ellipse's anchor icon of the `x` or `y` axis or the origin `o`'s color and size
 
-
-### Example
 ```js
 const options = {
   backgroundOpacity: 0.33,
@@ -137,3 +134,84 @@ Set the ellipse's radius on the `x` axis
 `PropsTypes.number`
 
 Set the ellipse's radius on the `y` axis
+
+# Methods
+To use methods that `DamageHighlight` exposes one has to create a component `ref` and invoke them using it.
+## createDamageView(damageType, partType)
+`PropTypes.func`
+
+Create a damage containing a `damageType: PropTypes.string` and a `partType: PropTypes.string` then create a new view on the current image of the inspection with the bounding box calculated from the ellipse.
+
+```js
+// ...
+const damageAnnotationRef = useRef(null);
+
+const createDamageView = useCallback(async () => {
+  const base64 = await damageAnnotationRef.current.createDamageView('dent', 'bumper_back');
+}, [damageAnnotationRef]);
+
+// ...
+<DamageAnnotation ref={damageAnnotationRef} image={inspection.images[0]} />
+```
+
+# Example
+
+
+``` javascript
+import React, { useState, useRef, useCallback } from 'react';
+import { DamageAnnotation } from '@monkvision/visualization';
+
+// Usage example
+const image = {
+  id: "uuid", // image's uuid
+  width: 0, // original size of the image
+  height: 0,
+  source: {
+    uri: "https://my_image_path.monk.ai"
+  },
+};
+
+export default function App() {
+  const ref = useRef(null);
+  const [inspection, setInspection] = useState(null);
+  const [partType, setPartType] = useState(null);
+  const [damageType, setDamageType] = useState(null);
+
+  const renderOptions = { width: 400, height: 220, rx: 100, ry: 100 };
+  const options = {
+    polygons: {
+      opacity: 0.5,
+      stroke: {
+        color: 'green',
+        strokeWidth: 50,
+      }
+    },
+    label: {
+      fontSize: 20,
+    },
+    background: {
+      opacity: 0.35,
+    },
+  }
+
+  const handleAddDamage = useCallback(async () => {
+    const newDamageView = await ref.current.createDamageView(damageType, partType);
+  }, [ref]);
+
+  return (
+    <View>
+      <DamageAnnotation
+        image={image}
+        options={options}
+        renderOptions={renderOptions}
+        clip
+        ref={ref}
+      />
+      <Input onChange={setDamageType} placeholder="damage type?" />
+      <Input onChange={setPartType} placeholder="part type?" />
+      <Button onPress={handleAddDamage}>Add damage</Button>
+    </View>
+  )
+}
+
+```


### PR DESCRIPTION
<!--- Please request a review from the leader or members from the FE team  -->

## Technical description
<!--- Describe your changes technically in detail -->

* Modifications on the DamageHighlight component : 
  * Creation of ElementHighlight for a generalization of the component to create other component (for instance PartHighlight)
  * Remove damage labels, because if there are too much damages, it can quickly become unreadable
  * Modification of the props of DamageHighlight for an easier use of the component by putting inspection's image and damages
  * Manual damages are represent by ellipses and AI detected damages by an ellipse
  * Fix some warning messages about click/press event
* Modifications on the DamageAnnotation component :
  * Add `Reset` and `CreateDamageView` ref functions to add a damage on a an already uploaded image or on a new image to upload
* Update documentation
* Fix on Inspection report app, the `get inspections` request error

## Tested on
<!--- Please provide all devices used while testing -->

- Chrome Browser
- 

## Steps to reproduce
<!--- Steps in details to reproduce the solved issue use cases  -->

1. 
2. 

## Screenshots (optional):

No screenshots.

*This Pull Request template has been written and generated by Monk JS repository.*
![Screenshot from 2022-09-05 14-01-32](https://user-images.githubusercontent.com/71043267/188444264-40f759a7-d381-4708-b268-cac7cdde541e.png)

![Screenshot from 2022-09-05 17-24-51](https://user-images.githubusercontent.com/71043267/188481195-c7020ab6-bea8-43de-8f46-a1a26f4f59c8.png)

![Screenshot from 2022-09-05 17-25-39](https://user-images.githubusercontent.com/71043267/188481286-31a87d0c-b0b2-45f4-b612-32cb236ac89a.png)


