### PR TITLE
retake the picture instead of reuploading the picture

### DIFF
--- a/packages/camera/src/components/UploadCenter/UploadCard/hooks/useVariant.js
+++ b/packages/camera/src/components/UploadCenter/UploadCard/hooks/useVariant.js
@@ -12,10 +12,10 @@ export default function useThumbnail({
     if (isPending) { return { callback: null, color: colors.placeholder }; }
     if (isUploadFailed) {
       return {
-        label: t('uploadCenter.variant.reupload.label'),
-        icon: 'refresh-circle',
-        callback: handleReupload,
-        sublable: t('uploadCenter.variant.reupload.sublabel'),
+        label: t('uploadCenter.variant.retake.label'),
+        icon: 'camera-retake',
+        callback: handleRetake,
+        sublable: t('uploadCenter.variant.retake.sublabel'),
         color: colors.error,
       };
     }

--- a/packages/camera/src/i18n/resources/en.js
+++ b/packages/camera/src/i18n/resources/en.js
@@ -27,7 +27,7 @@ const en = {
       subtitle: {
         unknown: 'Couldn\'t check the image quality',
         pending: 'Loading...',
-        failed: 'We couldn\'t upload this image, please reupload',
+        failed: 'We couldn\'t upload this image',
         idle: 'In the image quality check queue...',
         queueBlocked: 'We couldn\'t check the image quality (queue blocked)',
         reasonsStart: 'This image',

--- a/packages/camera/src/i18n/resources/fr.js
+++ b/packages/camera/src/i18n/resources/fr.js
@@ -27,7 +27,7 @@ const fr = {
       subtitle: {
         unknown: 'Impossible de vérifier la qualité de l\'image',
         pending: 'Chargement...',
-        failed: 'Impossible d\'upload l\'image, veuillez réessayer',
+        failed: 'Impossible d\'upload l\'image',
         idle: 'Dans la file d\'attente.',
         queueBlocked: 'Impossible de vérifier la qualité de l\'image (file d\'attente bloquée)',
         reasonsStart: 'Cette image',


### PR DESCRIPTION
<!--- Please request a review from the leader or members from the FE team  -->

## Technical description
Replace the functionality of "Reupload Picture" with "Retake Picture"
- When the picture was not uploaded correctly, KEEP the thumbnail color in red
- When the picture was not uploaded correctly, instead of displaying “reupload picture” we want to display “retake picture”
- When the picture was not uploaded correctly and the user clicks on the thumbnail, instead of trying to reupload the picture, we want to retake the picture (we want to have the same behaviour as for the not compliant images)

## Tested on
<!--- Please provide all devices used while testing -->

-
- 

## Steps to reproduce
<!--- Steps in details to reproduce the solved issue use cases  -->

1. 
2. 

## Screenshots (optional):

No screenshots.

*This Pull Request template has been written and generated by Monk JS repository.*

