### PR TITLE
Improve Capture UX

### DIFF
--- a/packages/camera/src/components/Camera/hooks/useCamera.js
+++ b/packages/camera/src/components/Camera/hooks/useCamera.js
@@ -17,7 +17,7 @@ const toBlob = (canvasElement, type) => new Promise((resolve) => {
  * and a canvas of width/height.
  */
 const diff = 1;
-const canvas = document.createElement('canvas');
+// const canvas = document.createElement('canvas');
 const imageType = utils.supportsWebP ? 'image/webp' : 'image/jpeg';
 const imageFilenameExtension = imageType.substring('image/'.length);
 
@@ -57,12 +57,16 @@ export default function useCamera({
   }, [stream, error]);
 
   // we can set the canvas dimensions one time rather than on every time we press capture
-  useEffect(() => { canvas.width = width; canvas.height = height; }, [width, height]);
+  // useEffect(() => { canvas.width = width; canvas.height = height; }, [width, height]);
 
   const takePicture = useCallback(async () => {
     if (!videoRef.current || !stream) { throw new Error('Camera is not ready!'); }
 
     let webCaptureTracing;
+    // we can create and use the separate canvas for each sight pic
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
     if (Sentry) { webCaptureTracing = new Span('web-capture', 'func'); }
     canvas.getContext('2d').drawImage(videoRef.current, 0, 0, width, height);
 
@@ -86,7 +90,10 @@ export default function useCamera({
       compressionTracing?.finish();
       uri = URL.createObjectURL(compressed);
     } else {
+      console.log('Start get the URL from canvas Blob');
       uri = await toBlob(canvas, imageType);
+      // uri = canvas.toDataURL(imageType);
+      console.log('End get the URL from canvas Blob');
     }
 
     webCaptureTracing?.finish();

--- a/packages/camera/src/components/Camera/hooks/useCamera.js
+++ b/packages/camera/src/components/Camera/hooks/useCamera.js
@@ -90,10 +90,8 @@ export default function useCamera({
       compressionTracing?.finish();
       uri = URL.createObjectURL(compressed);
     } else {
-      console.log('Start get the URL from canvas Blob');
       uri = await toBlob(canvas, imageType);
       // uri = canvas.toDataURL(imageType);
-      console.log('End get the URL from canvas Blob');
     }
 
     webCaptureTracing?.finish();

--- a/packages/camera/src/components/Capture/capture.js
+++ b/packages/camera/src/components/Capture/capture.js
@@ -230,7 +230,7 @@ const Capture = forwardRef(({
 
   const windowDimensions = useWindowDimensions();
   const tourHasFinished = useMemo(
-    () => Object.values(uploads.state).every(({ status, picture, uploadCount }) => (picture || status === 'rejected') && uploadCount >= 1),
+    () => Object.values(uploads.state).every(({ status, uploadCount }) => (status === 'rejected' || status === 'fulfilled') && uploadCount >= 1),
     [uploads.state],
   );
   const overlaySize = useMemo(

--- a/packages/camera/src/components/Capture/hooks.js
+++ b/packages/camera/src/components/Capture/hooks.js
@@ -122,8 +122,11 @@ export function useSetPictureAsync({ current, sights, uploads, Sentry }) {
       sights.dispatch({ type: Actions.sights.SET_PICTURE, payload });
       uploads.dispatch({ type: Actions.uploads.UPDATE_UPLOAD, payload });
     } catch (err) {
+      const payload = { id: current.id, status: 'rejected', error: err };
+      uploads.dispatch({ type: Actions.uploads.UPDATE_UPLOAD, increment: true, payload });
       errorHandler(err, SentryConstants.type.CAMERA, { id: current.id, picture });
       log([`Error in \`<Capture />\` \`setPictureAsync()\`: ${err}`], 'error');
+      throw err;
     }
   }, [current.id, sights, uploads]);
 }

--- a/packages/camera/src/components/Controls/hooks.js
+++ b/packages/camera/src/components/Controls/hooks.js
@@ -50,7 +50,7 @@ const useHandlers = ({
       }
     }, 500);
 
-    log([`[Click] Taking a photo-${current.index}`]);
+    log([`[Click] Taking a photo`]);
     const picture = await takePictureAsync();
 
     if (!picture) { return; }

--- a/packages/camera/src/components/Controls/hooks.js
+++ b/packages/camera/src/components/Controls/hooks.js
@@ -31,8 +31,6 @@ const useHandlers = ({
     const state = controlledState || unControlledState;
     event.preventDefault();
 
-    onStartUploadPicture(state, api);
-
     const {
       takePictureAsync,
       startUploadAsync,
@@ -40,26 +38,26 @@ const useHandlers = ({
       goNextSight,
     } = api;
 
-    log(['[Click] Taking a photo']);
+    const { sights } = state;
+    const { current, ids } = sights.state;
+
+    onStartUploadPicture(state, api);
+
+    setTimeout(() => {
+      if (current.index !== (ids.length - 1)) {
+        onFinishUploadPicture(state, api);
+        goNextSight();
+      }
+    }, 500);
+
+    log([`[Click] Taking a photo-${current.index}`]);
     const picture = await takePictureAsync();
 
     if (!picture) { return; }
 
     setPictureAsync(picture);
 
-    const { sights } = state;
-    const { current, ids } = sights.state;
-
-    if (current.index === ids.length - 1) {
-      await startUploadAsync(picture);
-    } else {
-      await startUploadAsync(picture);
-
-      setTimeout(() => {
-        onFinishUploadPicture(state, api);
-        goNextSight();
-      }, 500);
-    }
+    await startUploadAsync(picture);
     captureButtonTracing?.finish();
   }, [enableComplianceCheck, onFinishUploadPicture, onStartUploadPicture, stream]);
 

--- a/packages/camera/src/components/Controls/hooks.js
+++ b/packages/camera/src/components/Controls/hooks.js
@@ -55,10 +55,14 @@ const useHandlers = ({
 
     if (!picture) { return; }
 
-    setPictureAsync(picture);
-
-    await startUploadAsync(picture);
-    captureButtonTracing?.finish();
+    try {
+      await setPictureAsync(picture);
+      await startUploadAsync(picture);
+    } catch (err) {
+      log([`Error in \`<Capture />\` \`set an upload PictureAsync()\`: ${err}`], 'error');
+    } finally {
+      captureButtonTracing?.finish();
+    }
   }, [enableComplianceCheck, onFinishUploadPicture, onStartUploadPicture, stream]);
 
   const customCapture = useCallback(async (api, event) => {


### PR DESCRIPTION
1. Allow the user to capture the image for next sight without waiting for the whole operation completion on previous sight's picture.
2. Allow the user to move to next sight after 1/2 second only and then user can click on the capture button to trigger the call to capture the image.
3. The line up operations on the picture will be executed in background like creating a blob from Canvas element and get URI, generating a thumbnail, and uploading the image with given task_name etc.
4. Once every picture status will be updated to either 'rejected' or 'fulfilled' then user will be taken to "Upload Centre".
5. Handling failure scenario for each operation for instance <thumbnail creation>