### PR TITLE
made a few minor changes to optimize HTML5 canvas for Android device

### DIFF
--- a/packages/camera/src/components/Camera/hooks/useCamera.js
+++ b/packages/camera/src/components/Camera/hooks/useCamera.js
@@ -7,17 +7,11 @@ import useUserMedia from './useUserMedia';
 import useCompression from './useCompression';
 import log from '../../../utils/log';
 
-// get url from canvas blob, because `canvas.toDataUrl` can't be revoked programmatically
-const toBlob = (canvasElement, type) => new Promise((resolve) => {
-  canvasElement.toBlob((blob) => resolve(URL.createObjectURL(blob)), type, 1);
-});
-
 /**
  * Note(Ilyass): As a solution we are using a video constraints of width/height + `diff`
  * and a canvas of width/height.
  */
 const diff = 1;
-// const canvas = document.createElement('canvas');
 const imageType = utils.supportsWebP ? 'image/webp' : 'image/jpeg';
 const imageFilenameExtension = imageType.substring('image/'.length);
 
@@ -56,9 +50,6 @@ export default function useCamera({
     }
   }, [stream, error]);
 
-  // we can set the canvas dimensions one time rather than on every time we press capture
-  // useEffect(() => { canvas.width = width; canvas.height = height; }, [width, height]);
-
   const takePicture = useCallback(async () => {
     if (!videoRef.current || !stream) { throw new Error('Camera is not ready!'); }
 
@@ -68,7 +59,7 @@ export default function useCamera({
     canvas.width = width;
     canvas.height = height;
     if (Sentry) { webCaptureTracing = new Span('web-capture', 'func'); }
-    canvas.getContext('2d').drawImage(videoRef.current, 0, 0, width, height);
+    canvas.getContext('2d', { alpha: false }).drawImage(videoRef.current, 0, 0, width, height);
 
     let uri;
     if (enableCompression && !utils.supportsWebP()) {
@@ -90,8 +81,7 @@ export default function useCamera({
       compressionTracing?.finish();
       uri = URL.createObjectURL(compressed);
     } else {
-      uri = await toBlob(canvas, imageType);
-      // uri = canvas.toDataURL(imageType);
+      uri = canvas.toDataURL(imageType);
     }
 
     webCaptureTracing?.finish();


### PR DESCRIPTION
Made a few modification to optimise HTML 5 canvas specially for following things:
1. Using `alpha=false` while drawing an image into canvas 2d context from video
2. Using `toDataURL` method directly on canvas instead of creating a Blob object from canvas and then get URI