### PR TITLE
Feat/sentry performance measuring

### DIFF
--- a/packages/camera/src/components/Capture/capture.js
+++ b/packages/camera/src/components/Capture/capture.js
@@ -211,9 +211,11 @@ const Capture = forwardRef(({
     additionalPictures,
     compliance,
     isReady,
+    inspectionId,
     settings,
     sights,
     uploads,
+    task,
   }), [additionalPictures, compliance, isReady, settings, sights, uploads]);
 
   const hideAddDamage = useMemo(

--- a/packages/camera/src/components/Capture/hooks.js
+++ b/packages/camera/src/components/Capture/hooks.js
@@ -130,7 +130,6 @@ export function useSetPictureAsync({
     } catch (err) {
       const payload = { id: current.id, status: 'rejected', error: err };
       uploads.dispatch({ type: Actions.uploads.UPDATE_UPLOAD, increment: true, payload });
-      // sentry code for error capturing
       errorHandler(err);
       log([`Error in \`<Capture />\` \`setPictureAsync()\`: ${err}`], 'error');
       throw err;
@@ -227,7 +226,6 @@ export function useStartUploadAsync({
             payload: { pictureId: result.id, id, status: 'fulfilled', error: null },
           });
         } catch (err) {
-          // sentry code for error capturing
           errorHandler(err);
           dispatch({
             type: Actions.uploads.UPDATE_UPLOAD,

--- a/packages/camera/src/components/Capture/hooks.js
+++ b/packages/camera/src/components/Capture/hooks.js
@@ -1,4 +1,4 @@
-import monk from '@monkvision/corejs';
+import monk, { useMonitoring } from '@monkvision/corejs';
 import { utils } from '@monkvision/toolkit';
 import axios from 'axios';
 import { Buffer } from 'buffer';
@@ -97,6 +97,8 @@ export function useSetPictureAsync({
   sights,
   uploads,
 }) {
+  const { errorHandler } = useMonitoring();
+
   return useCallback(async (picture) => {
     try {
       const uri = picture.localUri || picture.uri;
@@ -128,7 +130,8 @@ export function useSetPictureAsync({
     } catch (err) {
       const payload = { id: current.id, status: 'rejected', error: err };
       uploads.dispatch({ type: Actions.uploads.UPDATE_UPLOAD, increment: true, payload });
-      // TODO: Add Monitoring code for error handling in MN-182
+      // sentry code for error capturing
+      errorHandler(err);
       log([`Error in \`<Capture />\` \`setPictureAsync()\`: ${err}`], 'error');
       throw err;
     }
@@ -187,6 +190,7 @@ export function useStartUploadAsync({
   endTour = false,
 }) {
   const [queue, setQueue] = useState([]);
+  const { errorHandler } = useMonitoring();
   let isRunning = false;
 
   const addElement = useCallback((element) => setQueue((prevState) => [...prevState, element]), []);
@@ -223,7 +227,8 @@ export function useStartUploadAsync({
             payload: { pictureId: result.id, id, status: 'fulfilled', error: null },
           });
         } catch (err) {
-          // TODO: Add Monitoring code for error handling in MN-182
+          // sentry code for error capturing
+          errorHandler(err);
           dispatch({
             type: Actions.uploads.UPDATE_UPLOAD,
             increment: true,

--- a/packages/camera/src/components/Capture/hooks.js
+++ b/packages/camera/src/components/Capture/hooks.js
@@ -202,7 +202,6 @@ export function useStartUploadAsync({
       if (queryParams) {
         const { id, picture, multiPartKeys, json, file } = queryParams;
         onWarningMessage('Upload...');
-        let uploadTracing;
 
         try {
           const data = new FormData();
@@ -233,7 +232,6 @@ export function useStartUploadAsync({
         } finally {
           URL.revokeObjectURL(picture.uri);
           onWarningMessage(null);
-          uploadTracing?.finish();
         }
       }
       isRunning = false;

--- a/packages/camera/src/components/Controls/hooks.js
+++ b/packages/camera/src/components/Controls/hooks.js
@@ -53,16 +53,13 @@ const useHandlers = ({
        * create a new transaction names 'Capture Sight' to measure the performance
        */
       const { TRANSACTION, OPERATION, SPAN, TAG } = SentryConst;
-      const transaction = measurePerformance(
-        TRANSACTION.pictureProcessing,
-        OPERATION.captureSight,
-        { sightId: current.id },
-      );
+      const transaction = measurePerformance(TRANSACTION.pictureProcessing, OPERATION.captureSight);
 
       /**
        * set tags to relate multiple transactions with a single inspection
        */
       transaction.setTag(TAG.task, task);
+      transaction.setTag(TAG.sightId, current.id);
       transaction.setTag(TAG.inspectionId, inspectionId);
 
       // add a process to queue

--- a/packages/camera/src/components/Controls/hooks.js
+++ b/packages/camera/src/components/Controls/hooks.js
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { Platform } from 'react-native';
+import { useMonitoring, SentryConst } from '@monkvision/corejs';
 import Actions from '../../actions';
 import log from '../../utils/log';
 
@@ -12,6 +13,7 @@ const useHandlers = ({
   onResetAddDamageStatus,
   onPictureTaken,
 }) => {
+  const { measurePerformance } = useMonitoring();
   const capture = useCallback(async (controlledState, api, event, addDamageParts) => {
     /** if the stream is not ready, we should not proceed to the capture callback, it will crash */
     if (!stream && Platform.OS === 'web') { return; }
@@ -21,7 +23,6 @@ const useHandlers = ({
      * `unControlledState` is the updated state, so it will be used for function that depends on
      * state updates (checkCompliance in this case that need to know when the picture is uploaded)
      */
-    let captureButtonTracing;
     const state = controlledState || unControlledState;
     event.preventDefault();
 
@@ -32,7 +33,7 @@ const useHandlers = ({
       uploadAdditionalDamage,
     } = api;
 
-    const { sights } = state;
+    const { inspectionId, sights, task } = state;
     const { current } = sights.state;
 
     onStartUploadPicture(state, api);
@@ -48,22 +49,56 @@ const useHandlers = ({
       onPictureTaken({ picture, isZoomedPicture: true, sight: null });
       onResetAddDamageStatus();
     } else {
+      /**
+       * create a new transaction names 'Capture Sight' to measure the performance
+       */
+      const { TRANSACTION, OPERATION, SPAN, TAG } = SentryConst;
+      const transaction = measurePerformance(
+        TRANSACTION.pictureProcessing,
+        OPERATION.captureSight,
+        { sightId: current.id },
+      );
+
+      /**
+       * set tags to relate multiple transactions with a single inspection
+       */
+      transaction.setTag(TAG.task, task);
+      transaction.setTag(TAG.inspectionId, inspectionId);
+
       // add a process to queue
       sights.dispatch({
         type: Actions.sights.ADD_PROCESS_TO_QUEUE,
         payload: { id: current.id },
       });
 
-      log([`[Click] Taking a photo`]);
+      /**
+       * Take a pic from canvas and measure it's performance
+       */
+      transaction.startSpan(SPAN.takePic);
+      log([`[Click] Taking a pic has started`]);
       const picture = await takePictureAsync();
+      transaction.finishSpan(SPAN.takePic);
 
       if (!picture) { return; }
 
       try {
+        /**
+         * Create a thumbnail and measure it's performance
+         */
+        transaction.startSpan(SPAN.createThumbnail);
         await setPictureAsync(picture);
+        transaction.finishSpan(SPAN.createThumbnail);
+
+        /**
+         * Upload a pic and measure it's performance
+         */
+        transaction.startSpan(SPAN.uploadPic);
         await startUploadAsync(picture);
+        transaction.finishSpan(SPAN.uploadPic);
         onPictureTaken({ picture, isZoomedPicture: false, sight: current.id });
       } catch (err) {
+        transaction.finishSpan(SPAN.createThumbnail);
+        transaction.finishSpan(SPAN.uploadPic);
         log([`Error in \`<Capture />\` \`set an upload PictureAsync()\`: ${err}`], 'error');
       } finally {
         // remove a process from queue
@@ -71,10 +106,11 @@ const useHandlers = ({
           type: Actions.sights.REMOVE_PROCESS_FROM_QUEUE,
           payload: { id: current.id },
         });
+        // finish a running transaction
+        transaction.finish();
+        log([`[Click] Taking a pic has completed`]);
       }
     }
-
-    captureButtonTracing?.finish();
   }, [
     enableComplianceCheck,
     onFinishUploadPicture,

--- a/packages/corejs/src/monitoring/index.tsx
+++ b/packages/corejs/src/monitoring/index.tsx
@@ -24,7 +24,7 @@ export function MonitoringProvider({ children, config }: PropsWithChildren<Monit
       dsn: config.dsn,
       environment: config.environment,
       debug: config.debug,
-      tracesSampleRate: config.tracesSampleRate,
+      tracesSampleRate: config.tracesSampleRate || 0.1,
       integrations: [
         new BrowserTracing({ tracePropagationTargets: config.tracingOrigins }),
       ],

--- a/packages/corejs/src/monitoring/index.tsx
+++ b/packages/corejs/src/monitoring/index.tsx
@@ -3,7 +3,7 @@ import { BrowserTracing } from '@sentry/tracing';
 import React, { createContext, PropsWithChildren, useCallback, useContext, useEffect, useMemo } from 'react';
 import { Primitive, Span } from '@sentry/types';
 
-import { MonitoringContext, MonitoringProps, SentryTransactionObject, SentryTransactionStatus } from './types';
+import { MonitoringContext, MonitoringProps, SentryTransactionObject, MonitoringStatus } from './types';
 
 export * from './types';
 
@@ -83,7 +83,7 @@ export function MonitoringProvider({ children, config }: PropsWithChildren<Monit
 
     // Set transaction on scope to associate with errors and get included span instrumentation
     // If there's currently an unfinished transaction, it may be dropped
-    Sentry.getCurrentHub().configureScope((scope) => scope.setSpan(transaction));
+    // Sentry.getCurrentHub().configureScope((scope) => scope.setSpan(transaction));
 
     // Create an object to map spans for a transaction
     const transactionSpansObj = {};
@@ -96,13 +96,13 @@ export function MonitoringProvider({ children, config }: PropsWithChildren<Monit
       finishSpan: (spanOp: string) => {
         if (transactionSpansObj[spanOp]) {
           const spanObj:Span = transactionSpansObj[spanOp] as Span;
-          spanObj.setStatus(SentryTransactionStatus);
+          spanObj.setStatus(MonitoringStatus.Ok);
           spanObj.finish();
           delete transactionSpansObj[spanOp];
         }
       },
-      finish: () => {
-        transaction.setStatus(SentryTransactionStatus);
+      finish: (status: string = MonitoringStatus.Ok) => {
+        transaction.setStatus(status);
         transaction.finish();
       },
     };
@@ -123,7 +123,7 @@ export function MonitoringProvider({ children, config }: PropsWithChildren<Monit
     setTimeout(() => {
       transaction.setMeasurement(name, value, unit);
       transaction.setMeasurement('frames_total', value, unit);
-      transaction.setStatus(SentryTransactionStatus);
+      transaction.setStatus(MonitoringStatus.Ok);
       transaction.finish();
     }, 100);
   }, []);

--- a/packages/corejs/src/monitoring/index.tsx
+++ b/packages/corejs/src/monitoring/index.tsx
@@ -24,7 +24,7 @@ export function MonitoringProvider({ children, config }: PropsWithChildren<Monit
       dsn: config.dsn,
       environment: config.environment,
       debug: config.debug,
-      tracesSampleRate: config.tracesSampleRate || 0.1,
+      tracesSampleRate: config.tracesSampleRate ?? 0.1,
       integrations: [
         new BrowserTracing({ tracePropagationTargets: config.tracingOrigins }),
       ],
@@ -96,12 +96,12 @@ export function MonitoringProvider({ children, config }: PropsWithChildren<Monit
       finishSpan: (spanOp: string) => {
         if (transactionSpansObj[spanOp]) {
           const spanObj: Span = transactionSpansObj[spanOp] as Span;
-          spanObj.setStatus(MonitoringStatus.Ok);
+          spanObj.setStatus(MonitoringStatus.OK);
           spanObj.finish();
           delete transactionSpansObj[spanOp];
         }
       },
-      finish: (status: string = MonitoringStatus.Ok) => {
+      finish: (status: string = MonitoringStatus.OK) => {
         transaction.setStatus(status);
         transaction.finish();
       },
@@ -123,7 +123,7 @@ export function MonitoringProvider({ children, config }: PropsWithChildren<Monit
     setTimeout(() => {
       transaction.setMeasurement(name, value, unit);
       transaction.setMeasurement('frames_total', value, unit);
-      transaction.setStatus(MonitoringStatus.Ok);
+      transaction.setStatus(MonitoringStatus.OK);
       transaction.finish();
     }, 100);
   }, []);

--- a/packages/corejs/src/monitoring/index.tsx
+++ b/packages/corejs/src/monitoring/index.tsx
@@ -79,7 +79,7 @@ export function MonitoringProvider({ children, config }: PropsWithChildren<Monit
   */
   const measurePerformance = useCallback((name: string, op: string, data?: { [key: string]: number | string }): SentryTransactionObject => {
     // This will create a new Transaction
-    const transaction = Sentry.startTransaction({ name, data, op });
+    const transaction = Sentry.startTransaction({ name, data, op, sampled: true });
 
     // Set transaction on scope to associate with errors and get included span instrumentation
     // If there's currently an unfinished transaction, it may be dropped
@@ -95,7 +95,7 @@ export function MonitoringProvider({ children, config }: PropsWithChildren<Monit
       },
       finishSpan: (spanOp: string) => {
         if (transactionSpansObj[spanOp]) {
-          const spanObj:Span = transactionSpansObj[spanOp] as Span;
+          const spanObj: Span = transactionSpansObj[spanOp] as Span;
           spanObj.setStatus(MonitoringStatus.Ok);
           spanObj.finish();
           delete transactionSpansObj[spanOp];
@@ -118,7 +118,7 @@ export function MonitoringProvider({ children, config }: PropsWithChildren<Monit
    * @return {void}
    */
   const setMeasurement = useCallback((transactionName: string, name: string, value: number, unit?: string): void => {
-    const transaction = Sentry.startTransaction({ name: transactionName, op: name });
+    const transaction = Sentry.startTransaction({ name: transactionName, op: name, sampled: true });
 
     setTimeout(() => {
       transaction.setMeasurement(name, value, unit);

--- a/packages/corejs/src/monitoring/types.ts
+++ b/packages/corejs/src/monitoring/types.ts
@@ -31,6 +31,31 @@ export interface MonitoringConfig {
 }
 
 /**
+ * Sentry transaction object interface
+ */
+export interface SentryTransactionObject {
+  /**
+   * Set tag in a transaction instance
+   */
+  setTag: (name: string, value: string) => void;
+
+  /**
+   * Create a span in a transaction instance to measure the performance for a sub event
+   */
+  startSpan: (op: string, data: { [key: string]: number | string } | null) => void;
+
+  /**
+   * Finish a running span in a transaction instance and complete the measurement for a sub event
+   */
+  finishSpan: (op: string) => void;
+
+  /**
+   * Finish a running transaction instance and complete the measurement for a main event
+   */
+  finish: () => void;
+}
+
+/**
  * Monitoring context interface
 */
 export interface MonitoringContext {
@@ -47,7 +72,7 @@ export interface MonitoringContext {
   /**
    * Start Measure Performance
   */
-  measurePerformance: (name: string, op: string, data: { [key: string]: number | string } | null) => (() => void);
+  measurePerformance: (name: string, op: string, data: { [key: string]: number | string } | null) => SentryTransactionObject;
 
   /**
    * Set custom measurement value
@@ -66,3 +91,25 @@ export interface MonitoringProps {
 }
 
 export const SentryTransactionStatus = 'success';
+
+export const SentryConst = {
+  TRANSACTION: {
+    pictureProcessing: 'Picture Processing',
+  },
+  OPERATION: {
+    images_ocr: 'Image OCR',
+    damage_detection: 'Damage Detection',
+    captureTour: 'Capture Tour',
+    captureSight: 'Capture Sight',
+  },
+  SPAN: {
+    takePic: 'Take Pic',
+    createThumbnail: 'Create Thumbnail',
+    uploadPic: 'Upload Pic',
+  },
+  TAG: {
+    inspectionId: 'inspectionId',
+    sightId: 'sightId',
+    task: 'task',
+  },
+};

--- a/packages/corejs/src/monitoring/types.ts
+++ b/packages/corejs/src/monitoring/types.ts
@@ -95,39 +95,39 @@ export interface MonitoringProps {
  */
 export enum MonitoringStatus {
   /** The operation completed successfully. */
-  Ok = "ok",
+  Ok = 'ok',
   /** Deadline expired before operation could complete. */
-  DeadlineExceeded = "deadline_exceeded",
+  DeadlineExceeded = 'deadline_exceeded',
   /** 401 Unauthorized (actually does mean unauthenticated according to RFC 7235) */
-  Unauthenticated = "unauthenticated",
+  Unauthenticated = 'unauthenticated',
   /** 403 Forbidden */
-  PermissionDenied = "permission_denied",
+  PermissionDenied = 'permission_denied',
   /** 404 Not Found. Some requested entity (file or directory) was not found. */
-  NotFound = "not_found",
+  NotFound = 'not_found',
   /** 429 Too Many Requests */
-  ResourceExhausted = "resource_exhausted",
+  ResourceExhausted = 'resource_exhausted',
   /** Client specified an invalid argument. 4xx. */
-  InvalidArgument = "invalid_argument",
+  InvalidArgument = 'invalid_argument',
   /** 501 Not Implemented */
-  Unimplemented = "unimplemented",
+  Unimplemented = 'unimplemented',
   /** 503 Service Unavailable */
-  Unavailable = "unavailable",
+  Unavailable = 'unavailable',
   /** Other/generic 5xx. */
-  InternalError = "internal_error",
+  InternalError = 'internal_error',
   /** Unknown. Any non-standard HTTP status code. */
-  UnknownError = "unknown_error",
+  UnknownError = 'unknown_error',
   /** The operation was cancelled (typically by the user). */
-  Cancelled = "cancelled",
+  Cancelled = 'cancelled',
   /** Already exists (409) */
-  AlreadyExists = "already_exists",
+  AlreadyExists = 'already_exists',
   /** Operation was rejected because the system is not in a state required for the operation's */
-  FailedPrecondition = "failed_precondition",
+  FailedPrecondition = 'failed_precondition',
   /** The operation was aborted, typically due to a concurrency issue. */
-  Aborted = "aborted",
+  Aborted = 'aborted',
   /** Operation was attempted past the valid range. */
-  OutOfRange = "out_of_range",
+  OutOfRange = 'out_of_range',
   /** Unrecoverable data loss or corruption */
-  DataLoss = "data_loss"
+  DataLoss = 'data_loss',
 }
 
 export const SentryConst = {

--- a/packages/corejs/src/monitoring/types.ts
+++ b/packages/corejs/src/monitoring/types.ts
@@ -52,7 +52,7 @@ export interface SentryTransactionObject {
   /**
    * Finish a running transaction instance and complete the measurement for a main event
    */
-  finish: () => void;
+  finish: (status: string) => void;
 }
 
 /**
@@ -90,7 +90,45 @@ export interface MonitoringProps {
   config: MonitoringConfig;
 }
 
-export const SentryTransactionStatus = 'success';
+/**
+ * The status of an Transaction/Span.
+ */
+export enum MonitoringStatus {
+  /** The operation completed successfully. */
+  Ok = "ok",
+  /** Deadline expired before operation could complete. */
+  DeadlineExceeded = "deadline_exceeded",
+  /** 401 Unauthorized (actually does mean unauthenticated according to RFC 7235) */
+  Unauthenticated = "unauthenticated",
+  /** 403 Forbidden */
+  PermissionDenied = "permission_denied",
+  /** 404 Not Found. Some requested entity (file or directory) was not found. */
+  NotFound = "not_found",
+  /** 429 Too Many Requests */
+  ResourceExhausted = "resource_exhausted",
+  /** Client specified an invalid argument. 4xx. */
+  InvalidArgument = "invalid_argument",
+  /** 501 Not Implemented */
+  Unimplemented = "unimplemented",
+  /** 503 Service Unavailable */
+  Unavailable = "unavailable",
+  /** Other/generic 5xx. */
+  InternalError = "internal_error",
+  /** Unknown. Any non-standard HTTP status code. */
+  UnknownError = "unknown_error",
+  /** The operation was cancelled (typically by the user). */
+  Cancelled = "cancelled",
+  /** Already exists (409) */
+  AlreadyExists = "already_exists",
+  /** Operation was rejected because the system is not in a state required for the operation's */
+  FailedPrecondition = "failed_precondition",
+  /** The operation was aborted, typically due to a concurrency issue. */
+  Aborted = "aborted",
+  /** Operation was attempted past the valid range. */
+  OutOfRange = "out_of_range",
+  /** Unrecoverable data loss or corruption */
+  DataLoss = "data_loss"
+}
 
 export const SentryConst = {
   TRANSACTION: {
@@ -111,5 +149,6 @@ export const SentryConst = {
     inspectionId: 'inspectionId',
     sightId: 'sightId',
     task: 'task',
+    takenPictures: 'takenPictures',
   },
 };

--- a/packages/corejs/src/monitoring/types.ts
+++ b/packages/corejs/src/monitoring/types.ts
@@ -149,6 +149,10 @@ export const SentryConst = {
     inspectionId: 'inspectionId',
     sightId: 'sightId',
     task: 'task',
+    isSkip: 'isSkip',
+    isRetake: 'isRetake',
     takenPictures: 'takenPictures',
+    retakenPictures: 'retakenPictures',
+    percentOfNonCompliancePics: 'percentOfNonCompliancePics',
   },
 };

--- a/packages/corejs/src/monitoring/types.ts
+++ b/packages/corejs/src/monitoring/types.ts
@@ -95,64 +95,42 @@ export interface MonitoringProps {
  */
 export enum MonitoringStatus {
   /** The operation completed successfully. */
-  Ok = 'ok',
-  /** Deadline expired before operation could complete. */
-  DeadlineExceeded = 'deadline_exceeded',
-  /** 401 Unauthorized (actually does mean unauthenticated according to RFC 7235) */
-  Unauthenticated = 'unauthenticated',
-  /** 403 Forbidden */
-  PermissionDenied = 'permission_denied',
-  /** 404 Not Found. Some requested entity (file or directory) was not found. */
-  NotFound = 'not_found',
-  /** 429 Too Many Requests */
-  ResourceExhausted = 'resource_exhausted',
-  /** Client specified an invalid argument. 4xx. */
-  InvalidArgument = 'invalid_argument',
-  /** 501 Not Implemented */
-  Unimplemented = 'unimplemented',
-  /** 503 Service Unavailable */
-  Unavailable = 'unavailable',
-  /** Other/generic 5xx. */
-  InternalError = 'internal_error',
+  OK = 'ok',
   /** Unknown. Any non-standard HTTP status code. */
-  UnknownError = 'unknown_error',
+  UNKNOWN_ERROR = 'unknown_error',
   /** The operation was cancelled (typically by the user). */
-  Cancelled = 'cancelled',
-  /** Already exists (409) */
-  AlreadyExists = 'already_exists',
-  /** Operation was rejected because the system is not in a state required for the operation's */
-  FailedPrecondition = 'failed_precondition',
+  CANCELLED = 'cancelled',
   /** The operation was aborted, typically due to a concurrency issue. */
-  Aborted = 'aborted',
-  /** Operation was attempted past the valid range. */
-  OutOfRange = 'out_of_range',
-  /** Unrecoverable data loss or corruption */
-  DataLoss = 'data_loss',
+  ABORTED = 'aborted',
 }
 
-export const SentryConst = {
-  TRANSACTION: {
-    pictureProcessing: 'Picture Processing',
-  },
-  OPERATION: {
-    images_ocr: 'Image OCR',
-    damage_detection: 'Damage Detection',
-    captureTour: 'Capture Tour',
-    captureSight: 'Capture Sight',
-  },
-  SPAN: {
-    takePic: 'Take Pic',
-    createThumbnail: 'Create Thumbnail',
-    uploadPic: 'Upload Pic',
-  },
-  TAG: {
-    inspectionId: 'inspectionId',
-    sightId: 'sightId',
-    task: 'task',
-    isSkip: 'isSkip',
-    isRetake: 'isRetake',
-    takenPictures: 'takenPictures',
-    retakenPictures: 'retakenPictures',
-    percentOfNonCompliancePics: 'percentOfNonCompliancePics',
-  },
-};
+/**
+ * 
+ */
+export enum SentryTransaction {
+  PICTURE_PROCESSING = 'Picture Processing',
+}
+
+export enum SentryOperation {
+  IMAGES_OCR = 'Image OCR',
+  DAMAGE_DETECTION = 'Damage Detection',
+  CAPTURE_TOUR = 'Capture Tour',
+  CAPTURE_SIGHT = 'Capture Sight',
+}
+
+export enum SentrySpan {
+  TAKE_PIC = 'Take Pic',
+  CREATE_THUMBNAIL = 'Create Thumbnail',
+  UPLOAD_PIC = 'Upload Pic',
+}
+
+export enum SentryTag {
+  INSPECTION_ID = 'inspectionId',
+  SIGHT_ID = 'sightId',
+  TASK = 'task',
+  IS_SKIP = 'isSkip',
+  IS_RETAKE = 'isRetake',
+  TAKEN_PICTURES = 'takenPictures',
+  RETAKEN_PICTURES = 'retakenPictures',
+  PERCENT_OF_NON_COMPLIANCE_PICS = 'percentOfNonCompliancePics',
+}

--- a/packages/corejs/src/monitoring/types.ts
+++ b/packages/corejs/src/monitoring/types.ts
@@ -105,7 +105,7 @@ export enum MonitoringStatus {
 }
 
 /**
- * 
+ * The name of entities in Sentry
  */
 export enum SentryTransaction {
   PICTURE_PROCESSING = 'Picture Processing',

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -52,7 +52,6 @@ function App() {
       try {
         await SplashScreen.hideAsync();
       } catch (err) {
-        // sentry code for error capturing
         errorHandler(err);
       }
     }
@@ -69,7 +68,6 @@ function App() {
         // experience. Please remove this if you copy and paste the code!
         // await new Promise((resolve) => { setTimeout(resolve, 2000); });
       } catch (err) {
-        // sentry code for error capturing
         errorHandler(err);
       } finally {
         // Tell the application to render

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -52,6 +52,7 @@ function App() {
       try {
         await SplashScreen.hideAsync();
       } catch (err) {
+        // sentry code for error capturing
         errorHandler(err);
       }
     }
@@ -68,6 +69,7 @@ function App() {
         // experience. Please remove this if you copy and paste the code!
         // await new Promise((resolve) => { setTimeout(resolve, 2000); });
       } catch (err) {
+        // sentry code for error capturing
         errorHandler(err);
       } finally {
         // Tell the application to render

--- a/src/components/SilentAuth.js
+++ b/src/components/SilentAuth.js
@@ -29,14 +29,12 @@ export default function SilentAuth() {
           } else {
             AsyncStorage.removeItem(ASYNC_STORAGE_AUTH_KEY)
               .catch((err) => {
-                // sentry code for error capturing
                 errorHandler(err);
               });
           }
           setHasBeenDone(true);
         }
       }).catch((err) => {
-        // sentry code for error capturing
         errorHandler(err);
       });
     }

--- a/src/components/SilentAuth.js
+++ b/src/components/SilentAuth.js
@@ -10,7 +10,7 @@ import jwt_decode from 'jwt-decode';
 export default function SilentAuth() {
   const [hasBeenDone, setHasBeenDone] = useState(false);
   const dispatch = useDispatch();
-  const { setMonitoringUser } = useMonitoring();
+  const { errorHandler, setMonitoringUser } = useMonitoring();
 
   useEffect(() => {
     if (!hasBeenDone) {
@@ -28,14 +28,16 @@ export default function SilentAuth() {
             onAuthenticationSuccess(authentication, dispatch);
           } else {
             AsyncStorage.removeItem(ASYNC_STORAGE_AUTH_KEY)
-              .catch(() => {
-                // TODO: Add Monitoring code for error handling in MN-182
+              .catch((err) => {
+                // sentry code for error capturing
+                errorHandler(err);
               });
           }
           setHasBeenDone(true);
         }
-      }).catch(() => {
-        // TODO: Add Monitoring code for error handling in MN-182
+      }).catch((err) => {
+        // sentry code for error capturing
+        errorHandler(err);
       });
     }
   }, []);

--- a/src/components/SilentLang.js
+++ b/src/components/SilentLang.js
@@ -15,7 +15,6 @@ export default function SilentLang() {
         .then((value) => (value !== null ? i18n.changeLanguage(value) : Promise.resolve()))
         .then(() => setHasBeenDone(true))
         .catch((err) => {
-          // sentry code for error capturing
           errorHandler(err);
         });
     }

--- a/src/components/SilentLang.js
+++ b/src/components/SilentLang.js
@@ -2,9 +2,11 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ASYNC_STORAGE_LANG_KEY } from 'screens/Landing/LanguageSwitch';
+import { useMonitoring } from '@monkvision/corejs';
 
 export default function SilentLang() {
   const [hasBeenDone, setHasBeenDone] = useState(false);
+  const { errorHandler } = useMonitoring();
   const { i18n } = useTranslation();
 
   useEffect(() => {
@@ -12,8 +14,9 @@ export default function SilentLang() {
       AsyncStorage.getItem(ASYNC_STORAGE_LANG_KEY)
         .then((value) => (value !== null ? i18n.changeLanguage(value) : Promise.resolve()))
         .then(() => setHasBeenDone(true))
-        .catch(() => {
-          // TODO: Add Monitoring code for error handling in MN-182
+        .catch((err) => {
+          // sentry code for error capturing
+          errorHandler(err);
         });
     }
   }, []);

--- a/src/hooks/useAuth/index.js
+++ b/src/hooks/useAuth/index.js
@@ -30,7 +30,6 @@ export default function useAuth() {
 
       dispatch(authSlice.actions.reset({ isSignedOut: true }));
     } catch (err) {
-      // sentry code for error capturing
       errorHandler(err);
       setLoggingOut(false);
     }

--- a/src/hooks/useAuth/index.js
+++ b/src/hooks/useAuth/index.js
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import monk from '@monkvision/corejs';
+import monk, { useMonitoring } from '@monkvision/corejs';
 import discoveries from 'config/discoveries';
 
 import { revokeAsync } from 'expo-auth-session';
@@ -13,6 +13,7 @@ export default function useAuth() {
   const auth = useSelector((state) => state.auth);
   const { accessToken, tokenType } = auth;
   const isAuthenticated = useMemo(() => Boolean(accessToken), [accessToken]);
+  const { errorHandler } = useMonitoring();
 
   // signOut
   const [isLoggingOut, setLoggingOut] = useState(false);
@@ -28,8 +29,9 @@ export default function useAuth() {
       await revokeAsync(config, discoveries);
 
       dispatch(authSlice.actions.reset({ isSignedOut: true }));
-    } catch (e) {
-      // TODO: Add Monitoring code for error handling in MN-182
+    } catch (err) {
+      // sentry code for error capturing
+      errorHandler(err);
       setLoggingOut(false);
     }
   }, [accessToken, dispatch, tokenType]);

--- a/src/hooks/useSignIn/index.js
+++ b/src/hooks/useSignIn/index.js
@@ -90,7 +90,6 @@ export default function useSignIn(callbacks = {}) {
       AsyncStorage.setItem(ASYNC_STORAGE_AUTH_KEY, dataToStore).then(() => {
         if (typeof onSuccess === 'function') { onSuccess(response); }
       }).catch((err) => {
-        // sentry code for error capturing
         errorHandler(err);
         if (typeof onSuccess === 'function') { onSuccess(response); }
       });

--- a/src/hooks/useSignIn/index.js
+++ b/src/hooks/useSignIn/index.js
@@ -53,7 +53,7 @@ export default function useSignIn(callbacks = {}) {
   const [isLoading, setIsLoading] = useState(false);
   const start = () => setIsLoading(true);
   const stop = () => setIsLoading(false);
-  const { setMonitoringUser } = useMonitoring();
+  const { errorHandler, setMonitoringUser } = useMonitoring();
 
   const [request, response, promptAsync] = useAuthRequest(
     {
@@ -89,8 +89,9 @@ export default function useSignIn(callbacks = {}) {
       const dataToStore = JSON.stringify(response.authentication);
       AsyncStorage.setItem(ASYNC_STORAGE_AUTH_KEY, dataToStore).then(() => {
         if (typeof onSuccess === 'function') { onSuccess(response); }
-      }).catch(() => {
-        // TODO: Add Monitoring code for error handling in MN-182
+      }).catch((err) => {
+        // sentry code for error capturing
+        errorHandler(err);
         if (typeof onSuccess === 'function') { onSuccess(response); }
       });
     }

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ const config = {
   dsn: Constants.manifest.extra.SENTRY_DSN,
   environment: Constants.manifest.extra.ENV,
   debug: Constants.manifest.extra.ENV !== 'production',
-  tracesSampleRate: 1,
+  tracesSampleRate: 0.1,
   tracingOrigins: ['localhost', 'cna.dev.monk.ai', 'cna-staging.dev.monk.ai', 'cna.preview.monk.ai', 'cna.monk.ai'],
 };
 

--- a/src/screens/Authentication/SignIn/index.js
+++ b/src/screens/Authentication/SignIn/index.js
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { View, StyleSheet, useWindowDimensions } from 'react-native';
 import { Button, Paragraph, Title, useTheme } from 'react-native-paper';
 import { Loader } from '@monkvision/ui';
+import { useMonitoring } from '@monkvision/corejs';
 
 import * as names from 'screens/names';
 
@@ -35,6 +36,7 @@ export default function SignIn() {
   const { isAuthenticated } = useAuth();
   const { height } = useWindowDimensions();
   const { colors, loaderDotsColors } = useTheme();
+  const { errorHandler } = useMonitoring();
   const { t } = useTranslation();
 
   const route = useRoute();
@@ -43,10 +45,11 @@ export default function SignIn() {
   const [authError, setAuthError] = useState(false);
   const [signIn, isSigningIn] = useSignIn({
     onStart: () => { utils.log(['[Click] Signing in']); },
-    onError: () => {
+    onError: (err) => {
       setAuthError(true);
       utils.log(['[Event] Sign in failed']);
-      // TODO: Add Monitoring code for error handling in MN-182
+      // sentry code for error capturing
+      errorHandler(err);
     },
   });
 

--- a/src/screens/Authentication/SignIn/index.js
+++ b/src/screens/Authentication/SignIn/index.js
@@ -48,7 +48,6 @@ export default function SignIn() {
     onError: (err) => {
       setAuthError(true);
       utils.log(['[Event] Sign in failed']);
-      // sentry code for error capturing
       errorHandler(err);
     },
   });

--- a/src/screens/Authentication/SignOut/index.js
+++ b/src/screens/Authentication/SignOut/index.js
@@ -27,7 +27,6 @@ export default function SignOut(props) {
   const handleOpenWithWebBrowser = () => {
     WebBrowser.openAuthSessionAsync(`${discoveries.endSessionEndpoint}${params}`)
       .catch((err) => {
-        // sentry code for error capturing
         errorHandler(err);
       });
     signOut();

--- a/src/screens/Authentication/SignOut/index.js
+++ b/src/screens/Authentication/SignOut/index.js
@@ -5,7 +5,7 @@ import { Button } from 'react-native-paper';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri } from 'expo-auth-session';
 
-import monk from '@monkvision/corejs';
+import monk, { useMonitoring } from '@monkvision/corejs';
 import discoveries from 'config/discoveries';
 import useAuth from 'hooks/useAuth';
 
@@ -21,12 +21,14 @@ const returnTo = makeRedirectUri({
 export default function SignOut(props) {
   const params = `?client_id=${monk.config.authConfig.clientId}&returnTo=${returnTo}`;
   const { signOut } = useAuth();
+  const { errorHandler } = useMonitoring();
   const { t } = useTranslation();
 
   const handleOpenWithWebBrowser = () => {
     WebBrowser.openAuthSessionAsync(`${discoveries.endSessionEndpoint}${params}`)
-      .catch(() => {
-        // TODO: Add Monitoring code for error handling in MN-182
+      .catch((err) => {
+        // sentry code for error capturing
+        errorHandler(err);
       });
     signOut();
   };

--- a/src/screens/InspectionCapture/index.js
+++ b/src/screens/InspectionCapture/index.js
@@ -186,12 +186,12 @@ export default function InspectionCapture() {
   const onSkipRetake = useCallback(() => {
     captureTourTransRef.current.transaction.setTag(SentryConst.TAG.isSkip, 1);
   }, []);
-  const onRetakeNeeded = useCallback(({ retakesNeeded }) => {
+  const onRetakeNeeded = useCallback(({ retakesNeeded = 0 }) => {
     if (!captureTourTransRef.current.hasRetakeCalled) {
       const { transaction } = captureTourTransRef.current;
-      const nonCompliancePercent = ((100 * retakesNeeded) / sightIds.length);
+      const percentOfNonCompliancePics = ((100 * retakesNeeded) / sightIds.length);
       transaction.setTag(SentryConst.TAG.retakenPictures, retakesNeeded);
-      transaction.setTag(SentryConst.TAG.percentOfNonCompliancePics, nonCompliancePercent);
+      transaction.setTag(SentryConst.TAG.percentOfNonCompliancePics, percentOfNonCompliancePics);
     }
   }, []);
 

--- a/src/screens/InspectionCapture/index.js
+++ b/src/screens/InspectionCapture/index.js
@@ -23,7 +23,7 @@ export default function InspectionCapture() {
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { measurePerformance } = useMonitoring();
+  const { errorHandler, measurePerformance } = useMonitoring();
 
   const { inspectionId, sightIds, taskName, vehicleType, selectedMode } = route.params;
 
@@ -100,7 +100,8 @@ export default function InspectionCapture() {
         captureTourTransactionRef.current.finish();
         handleNavigate();
       } catch (err) {
-        // TODO: Add Monitoring code for error handling in MN-182
+        // sentry code for error capturing
+        errorHandler(err);
         setCameraLoading(false);
       }
     }
@@ -137,7 +138,8 @@ export default function InspectionCapture() {
           setSuccess(true);
         }
       } catch (err) {
-        // TODO: Add Monitoring code for error handling in MN-182
+        // sentry code for error capturing
+        errorHandler(err);
         // eslint-disable-next-line no-console
         console.error(err);
         throw err;

--- a/src/screens/InspectionCapture/index.js
+++ b/src/screens/InspectionCapture/index.js
@@ -108,7 +108,6 @@ export default function InspectionCapture() {
         captureTourTransRef.current.transaction.finish();
         handleNavigate();
       } catch (err) {
-        // sentry code for error capturing
         errorHandler(err);
         setCameraLoading(false);
       }
@@ -155,7 +154,6 @@ export default function InspectionCapture() {
           setSuccess(true);
         }
       } catch (err) {
-        // sentry code for error capturing
         errorHandler(err);
         // eslint-disable-next-line no-console
         console.error(err);

--- a/src/screens/InspectionCreate/index.js
+++ b/src/screens/InspectionCreate/index.js
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { View, StyleSheet, useWindowDimensions } from 'react-native';
 import { Button, Paragraph, Title, useTheme } from 'react-native-paper';
 import { Loader } from '@monkvision/ui';
+import { useMonitoring } from '@monkvision/corejs';
 import isEmpty from 'lodash.isempty';
 
 import * as names from 'screens/names';
@@ -39,6 +40,7 @@ export default function InspectionCreate() {
   const navigation = useNavigation();
   const { isAuthenticated, accessToken } = useAuth();
   const { height } = useWindowDimensions();
+  const { errorHandler } = useMonitoring();
   const { t } = useTranslation();
   const { colors, loaderDotsColors } = useTheme();
 
@@ -55,8 +57,9 @@ export default function InspectionCreate() {
 
   const [authError, setAuthError] = useState(false);
   const [signIn, isSigningIn] = useSignIn({
-    onError: () => {
-      // TODO: Add Monitoring code for error handling in MN-182
+    onError: (err) => {
+      // sentry code for error capturing
+      errorHandler(err);
       setAuthError(true);
     },
   });
@@ -118,7 +121,10 @@ export default function InspectionCreate() {
   }, [isAuthenticated, inspectionId, handleCreate, createInspection]));
 
   useEffect(() => {
-    // TODO: Add Monitoring code for error handling in MN-182
+    if (createInspection.state.error) {
+      // sentry code for error capturing
+      errorHandler(createInspection.state.error);
+    }
   }, [createInspection.state.error]);
 
   if (isSigningIn) {

--- a/src/screens/InspectionCreate/index.js
+++ b/src/screens/InspectionCreate/index.js
@@ -58,7 +58,6 @@ export default function InspectionCreate() {
   const [authError, setAuthError] = useState(false);
   const [signIn, isSigningIn] = useSignIn({
     onError: (err) => {
-      // sentry code for error capturing
       errorHandler(err);
       setAuthError(true);
     },
@@ -122,7 +121,6 @@ export default function InspectionCreate() {
 
   useEffect(() => {
     if (createInspection.state.error) {
-      // sentry code for error capturing
       errorHandler(createInspection.state.error);
     }
   }, [createInspection.state.error]);

--- a/src/screens/InspectionList/index.js
+++ b/src/screens/InspectionList/index.js
@@ -71,7 +71,6 @@ export default function InspectionList({ listItemProps, scrollViewProps, ...prop
     const url = `https://${Constants.manifest.extra.IRA_DOMAIN}/inspection/${id}`;
     WebBrowser.openBrowserAsync(url)
       .catch((err) => {
-        // sentry code for error capturing
         errorHandler(err);
       });
   }, []);
@@ -83,7 +82,6 @@ export default function InspectionList({ listItemProps, scrollViewProps, ...prop
 
   useEffect(() => {
     if (manyInspections.error) {
-      // sentry code for error capturing
       errorHandler(manyInspections.error);
     }
   }, [manyInspections.error]);

--- a/src/screens/InspectionList/index.js
+++ b/src/screens/InspectionList/index.js
@@ -12,7 +12,7 @@ import useAuth from 'hooks/useAuth';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { Loader } from '@monkvision/ui';
 import { useRequest } from '@monkvision/toolkit';
-import monk from '@monkvision/corejs';
+import monk, { useMonitoring } from '@monkvision/corejs';
 
 import { List, Paragraph, Title, useTheme } from 'react-native-paper';
 
@@ -32,6 +32,7 @@ export default function InspectionList({ listItemProps, scrollViewProps, ...prop
   const navigation = useNavigation();
   const { isAuthenticated } = useAuth();
   const { loaderDotsColors } = useTheme();
+  const { errorHandler } = useMonitoring();
   const { t } = useTranslation();
 
   const getManyInspections = useCallback(async () => monk.entity.inspection.getMany({
@@ -69,8 +70,9 @@ export default function InspectionList({ listItemProps, scrollViewProps, ...prop
   const handlePress = useCallback((id) => {
     const url = `https://${Constants.manifest.extra.IRA_DOMAIN}/inspection/${id}`;
     WebBrowser.openBrowserAsync(url)
-      .catch(() => {
-        // TODO: Add Monitoring code for error handling in MN-182
+      .catch((err) => {
+        // sentry code for error capturing
+        errorHandler(err);
       });
   }, []);
 
@@ -80,7 +82,10 @@ export default function InspectionList({ listItemProps, scrollViewProps, ...prop
   );
 
   useEffect(() => {
-    // TODO: Add Monitoring code for error handling in MN-182
+    if (manyInspections.error) {
+      // sentry code for error capturing
+      errorHandler(manyInspections.error);
+    }
   }, [manyInspections.error]);
 
   if (manyInspections.loading) {

--- a/src/screens/InspectionVehicleUpdate/index.js
+++ b/src/screens/InspectionVehicleUpdate/index.js
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { View, StyleSheet, useWindowDimensions } from 'react-native';
 import { Button, Paragraph, Title, useTheme } from 'react-native-paper';
 import { Loader } from '@monkvision/ui';
+import { useMonitoring } from '@monkvision/corejs';
 
 import * as names from 'screens/names';
 
@@ -36,6 +37,7 @@ export default function InspectionVehicleUpdate() {
   const navigation = useNavigation();
   const { isAuthenticated, accessToken } = useAuth();
   const { height } = useWindowDimensions();
+  const { errorHandler } = useMonitoring();
   const { t } = useTranslation();
   const { colors, loaderDotsColors } = useTheme();
 
@@ -45,8 +47,9 @@ export default function InspectionVehicleUpdate() {
 
   const [authError, setAuthError] = useState(false);
   const [signIn, isSigningIn] = useSignIn({
-    onError: () => {
-      // TODO: Add Monitoring code for error handling in MN-182
+    onError: (err) => {
+      // sentry code for error capturing
+      errorHandler(err);
       setAuthError(true);
     },
   });
@@ -84,7 +87,8 @@ export default function InspectionVehicleUpdate() {
   useEffect(() => {
     const { state } = updateInspectionVehicle;
     if (state.error) {
-      // TODO: Add Monitoring code for error handling in MN-182
+      // sentry code for error capturing
+      errorHandler(state.error);
     }
   }, [updateInspectionVehicle.state.error]);
 

--- a/src/screens/InspectionVehicleUpdate/index.js
+++ b/src/screens/InspectionVehicleUpdate/index.js
@@ -48,7 +48,6 @@ export default function InspectionVehicleUpdate() {
   const [authError, setAuthError] = useState(false);
   const [signIn, isSigningIn] = useSignIn({
     onError: (err) => {
-      // sentry code for error capturing
       errorHandler(err);
       setAuthError(true);
     },
@@ -87,7 +86,6 @@ export default function InspectionVehicleUpdate() {
   useEffect(() => {
     const { state } = updateInspectionVehicle;
     if (state.error) {
-      // sentry code for error capturing
       errorHandler(state.error);
     }
   }, [updateInspectionVehicle.state.error]);

--- a/src/screens/Landing/LanguageSwitch/index.js
+++ b/src/screens/Landing/LanguageSwitch/index.js
@@ -23,7 +23,6 @@ export default function LanguageSwitch() {
       .then(() => setIsLoading(false))
       .catch((err) => {
         setIsLoading(false);
-        // sentry code for error capturing
         errorHandler(err);
       });
   };

--- a/src/screens/Landing/LanguageSwitch/index.js
+++ b/src/screens/Landing/LanguageSwitch/index.js
@@ -2,12 +2,14 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ActivityIndicator, Button, Menu } from 'react-native-paper';
+import { useMonitoring } from '@monkvision/corejs';
 
 export const ASYNC_STORAGE_LANG_KEY = '@lang_Storage';
 
 export default function LanguageSwitch() {
   const [isLoading, setIsLoading] = useState(false);
   const [visible, setVisible] = React.useState(false);
+  const { errorHandler } = useMonitoring();
   const { i18n } = useTranslation();
 
   const openMenu = () => setVisible(true);
@@ -19,9 +21,10 @@ export default function LanguageSwitch() {
     i18n.changeLanguage(lng)
       .then(() => AsyncStorage.setItem(ASYNC_STORAGE_LANG_KEY, lng))
       .then(() => setIsLoading(false))
-      .catch(() => {
+      .catch((err) => {
         setIsLoading(false);
-        // TODO: Add Monitoring code for error handling in MN-182
+        // sentry code for error capturing
+        errorHandler(err);
       });
   };
 

--- a/src/screens/Landing/SignOut/index.js
+++ b/src/screens/Landing/SignOut/index.js
@@ -19,7 +19,6 @@ export default function SignOut({ onSuccess }) {
     // TODO: Add Monitoring code for setUser in MN-182
     AsyncStorage.removeItem(ASYNC_STORAGE_AUTH_KEY)
       .catch((err) => {
-        // sentry code for error capturing
         errorHandler(err);
       });
     dispatchSignOut(dispatch);

--- a/src/screens/Landing/SignOut/index.js
+++ b/src/screens/Landing/SignOut/index.js
@@ -6,18 +6,21 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, useTheme } from 'react-native-paper';
 import { useDispatch } from 'react-redux';
+import { useMonitoring } from '@monkvision/corejs';
 
 export default function SignOut({ onSuccess }) {
   const { colors } = useTheme();
   const dispatch = useDispatch();
+  const { errorHandler } = useMonitoring();
   const { t } = useTranslation();
 
   const signOut = () => {
     utils.log(['[Click]', 'Sign-out user']);
     // TODO: Add Monitoring code for setUser in MN-182
     AsyncStorage.removeItem(ASYNC_STORAGE_AUTH_KEY)
-      .catch(() => {
-        // TODO: Add Monitoring code for error handling in MN-182
+      .catch((err) => {
+        // sentry code for error capturing
+        errorHandler(err);
       });
     dispatchSignOut(dispatch);
 

--- a/src/screens/Landing/index.js
+++ b/src/screens/Landing/index.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import monk from '@monkvision/corejs';
+import monk, { useMonitoring } from '@monkvision/corejs';
 import { useInterval, utils } from '@monkvision/toolkit';
 import { Container } from '@monkvision/ui';
 import { useFocusEffect, useNavigation, useRoute } from '@react-navigation/native';
@@ -39,6 +39,7 @@ export default function Landing() {
   const navigation = useNavigation();
   const { isAuthenticated } = useAuth();
   const { height } = useWindowDimensions();
+  const { errorHandler } = useMonitoring();
   const { t, i18n } = useTranslation();
   const { setShowTranslatedMessage, Notice } = useSnackbar(true);
 
@@ -168,8 +169,9 @@ export default function Landing() {
 
   const start = useCallback(() => {
     if (inspectionId && getInspection.state.loading !== true) {
-      getInspection.start().catch(() => {
-        // TODO: Add Monitoring code for error handling in MN-182
+      getInspection.start().catch((err) => {
+        // sentry code for error capturing
+        errorHandler(err);
       });
     }
   }, [inspectionId, getInspection]);

--- a/src/screens/Landing/index.js
+++ b/src/screens/Landing/index.js
@@ -170,7 +170,6 @@ export default function Landing() {
   const start = useCallback(() => {
     if (inspectionId && getInspection.state.loading !== true) {
       getInspection.start().catch((err) => {
-        // sentry code for error capturing
         errorHandler(err);
       });
     }


### PR DESCRIPTION
Add metrics for performance measuring

## Description
* Number of errors per step in our SDK
* Metrics per sight
    * Time spent per sight
    * Time for take pic (Compression)
    * Time for thumbnail creation
    * Time for upload pic
* Metrics per capture tour
    * Total number of capture tour
    * Total number of capture tour finished
    * Total number of capture tour unfinished
    * Total number of capture tour with at least one picture taken (_consider both finished and unfinished tour_)
    * Average total time per finished capture tour
    * Average time spent per picture
    * Total number of capture tour for "Vin Number"
    * Total number of capture tour for "Damage Detection"
* Metrics per capture tour ( (_calculate this when user reach the upload center first time_))
    * retake
    * skips
    * percentage of non-compliance pics


## Technical Description
### tracesSampleRate
We have set **tracesSampleRate** to 0.1 for error events which means only 10% of error events will be sent to Sentry. It is a number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.). Applies equally to all transactions created in the app.



