### PR TITLE
feat: allow user to add custom tags (MN-274)

### DIFF
--- a/packages/corejs/src/monitoring/index.tsx
+++ b/packages/corejs/src/monitoring/index.tsx
@@ -46,6 +46,10 @@ export function MonitoringProvider({ children, config }: PropsWithChildren<Monit
         new BrowserTracing({ tracePropagationTargets: config.tracingOrigins }),
       ],
     });
+
+    if (config.customTags) {
+      Sentry.setTags(config.customTags);
+    }
   }, []);
 
   /**

--- a/packages/corejs/src/monitoring/types.ts
+++ b/packages/corejs/src/monitoring/types.ts
@@ -32,6 +32,10 @@ export interface MonitoringConfig {
    * Array of all the origin to browser trace.
   */
   tracingOrigins: string[];
+  /**
+   * Custom tags to add in all transaction.
+  */
+  customTags?: { [tag: string]: string };
 }
 
 /**

--- a/website/docs/monitoring.md
+++ b/website/docs/monitoring.md
@@ -24,13 +24,14 @@ The configuration options are listed below :
 
 ### Monitoring Config
 
-| **Config option**  | **Required** | **Type** | **Description**                                                                                                                                                                                   |
-| ------------------ | ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dsn`              | ✓            | string   | DSN (Data Source Name) key for sentry.io application. A DSN tells a Sentry SDK where to send events so the events are associated with the correct project.                                        |
-| `environment`      | ✓            | string   | The current environment of your application , such as _development_, _testing_, _staging_, or _production_. Environments help you better filter issues and transactions among other uses.         |
-| `debug`            | ✓            | boolean  | Enable debug functionality in the SDK itself. If debug is enabled SDK will attempt to print out useful debugging information in browser's console if something goes wrong with sending the event. |
-| `tracesSampleRate` | ✓            | number   | Sample rate to determine trace sampling. The default is 1.0 which means that 100% of error events are sent.                                                                                       |
-| `tracingOrigins`   | ✓            | string[] | Array of all the origin to browser trace                                                                                                                                                          |
+| **Config option**  | **Required** | **Type**                  | **Description**                                                                                                                                                                                   |
+| ------------------ | ------------ | --------                  | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dsn`              | ✓            | string                    | DSN (Data Source Name) key for sentry.io application. A DSN tells a Sentry SDK where to send events so the events are associated with the correct project.                                        |
+| `environment`      | ✓            | string                    | The current environment of your application , such as _development_, _testing_, _staging_, or _production_. Environments help you better filter issues and transactions among other uses.         |
+| `debug`            | ✓            | boolean                   | Enable debug functionality in the SDK itself. If debug is enabled SDK will attempt to print out useful debugging information in browser's console if something goes wrong with sending the event. |
+| `tracesSampleRate` | ✓            | number                    | Sample rate to determine trace sampling. The default is 1.0 which means that 100% of error events are sent.                                                                                       |
+| `tracingOrigins`   | ✓            | string[]                  | Array of all the origin to browser trace                                                                                                                                                          |
+| `customTags`       |              | { [tag: string]: string } | Add custom tags in all transactions for better tracking                                                                                                                                           |
 
 ### Note
 


### PR DESCRIPTION
Allow users to add custom tags at the time of initializing sentry. These custom tags will always be set in all the transactions.