### PR TITLE
Feature/mn-80/hotfix

### DIFF
--- a/packages/camera/src/components/Capture/capture.js
+++ b/packages/camera/src/components/Capture/capture.js
@@ -67,6 +67,10 @@ const styles = StyleSheet.create({
   },
   overlayContainer: {
     position: 'fixed',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100vw',
     height: '95vh',
     top: '2.5vh',
     zIndex: 99,
@@ -576,7 +580,7 @@ const Capture = forwardRef(({
             <Overlay
               svg={overlay}
               pathStyles={overlayPathStyles}
-              rootStyles={{ height: '100%' }}
+              rootStyles={{ width: 'auto', height: 'auto', maxWidth: '100%', maxHeight: '100%' }}
             />
           </View>
         ) : null}

--- a/packages/camera/src/components/Overlay/hooks/useCustomSVGAttributes.js
+++ b/packages/camera/src/components/Overlay/hooks/useCustomSVGAttributes.js
@@ -9,7 +9,7 @@ export default function useCustomSVGAttributes({
     const elementTag = element.tagName;
 
     if (elementTag === 'svg') {
-      return { style: rootStyles ?? {} };
+      return { style: rootStyles ?? {}, viewBox: '0 0 500 375' };
     }
 
     return { style: pathStyles ?? {} };

--- a/packages/camera/src/components/Overlay/hooks/useCustomSVGAttributes.js
+++ b/packages/camera/src/components/Overlay/hooks/useCustomSVGAttributes.js
@@ -9,6 +9,9 @@ export default function useCustomSVGAttributes({
     const elementTag = element.tagName;
 
     if (elementTag === 'svg') {
+      if (element.getAttribute('viewBox')) {
+        return { style: rootStyles ?? {} };
+      }
       return { style: rootStyles ?? {}, viewBox: '0 0 500 375' };
     }
 

--- a/packages/camera/src/components/Overlay/hooks/useJSXTransformAttributes.js
+++ b/packages/camera/src/components/Overlay/hooks/useJSXTransformAttributes.js
@@ -1,11 +1,24 @@
 import { useMemo } from 'react';
 
+function keyNameTransform(key) {
+  return key.split('-')
+    .map((val, index) => {
+      if (index) {
+        return val[0].toUpperCase() + val.substring(1).toLowerCase();
+      }
+      return val;
+    })
+    .join('');
+}
+
 function tranformJsxAttribute(key, value) {
   switch (key) {
     case 'class':
       return { key: 'className', value };
     case 'xml:space':
       return { key: 'xmlSpace', value };
+    case 'data-name':
+      return { key: 'dataname', value };
     case 'style':
       return value.split(';')
         .map((style) => style.split(':'))
@@ -18,7 +31,7 @@ function tranformJsxAttribute(key, value) {
           };
         }, {});
     default:
-      return { key, value };
+      return { key: keyNameTransform(key), value };
   }
 }
 

--- a/packages/camera/src/components/Thumbnail/index.js
+++ b/packages/camera/src/components/Thumbnail/index.js
@@ -88,7 +88,11 @@ export default function Thumbnail({
           <ActivityIndicator style={styles.loader} color={colors[uploadStatus]} />
           )}
           {(!picture && uploadStatus !== 'pending' && !!overlay) && (
-          <Overlay svg={overlay} style={styles.overlay} label={label} />
+            <Overlay
+              svg={overlay}
+              label={label}
+              rootStyles={{ width: 'auto', height: 'auto', maxWidth: '100%', maxHeight: '100%' }}
+            />
           )}
           <Text style={styles.text}>{label}</Text>
         </ImageBackground>


### PR DESCRIPTION
## Issues
<img width="400" alt="Screenshot 2023-05-31 at 2 14 13 AM" src="https://github.com/monkvision/monkjs/assets/86062128/4059662a-dc29-4e53-9c0a-01a58fb6cb20">
<img width="400" alt="Screenshot 2023-05-31 at 2 03 05 AM" src="https://github.com/monkvision/monkjs/assets/86062128/895c0021-c8aa-47a1-9ef9-6adea5981efa">
<img width="440" alt="Screenshot 2023-05-31 at 2 41 56 AM" src="https://github.com/monkvision/monkjs/assets/86062128/97c9c097-0b51-4b92-8233-e1690c09634d">



## Changes
1. Add style to keep SVG center aligned and scale them according to viewport width & height for both thumbnails and big views.
2. Add a function to change some attributes name in pascal case for `SVG` element for JSX parsing.
3. Add `viewBox` attribute on each `svg` element to make them scalable for thumbnails.