### PR TITLE
webapp/demo-capture@fix-client-param

### DIFF
--- a/src/screens/Landing/index.js
+++ b/src/screens/Landing/index.js
@@ -36,9 +36,9 @@ const ICON_BY_STATUS = {
 };
 
 const ClientParamMap = {
-  0: Clients.DEFAULT,
-  1: Clients.CAT,
-  2: Clients.FASTBACK,
+  d9m: Clients.DEFAULT,
+  pd8: Clients.CAT,
+  '2bd': Clients.FASTBACK,
 };
 
 const VehicleTypeMap = {
@@ -76,20 +76,22 @@ export default function Landing() {
     setClient(client);
   }, [setClient]);
 
-  const { inspectionId, token, vehicleTypeParam } = useMemo(() => {
+  const { clientId, inspectionId, token, vehicleTypeParam } = useMemo(() => {
     const urlParams = new URLSearchParams(window.location.search);
     const compressedToken = urlParams.get('t');
+    const clientParam = urlParams.get('c');
 
     return {
       inspectionId: urlParams.get('i'),
       vehicleTypeParam: urlParams.get('v') ?? 1,
+      clientId: clientParam ? ClientParamMap[clientParam] : undefined,
       token: compressedToken ? decompress(compressedToken) : undefined,
     };
   }, []);
 
   const invalidParams = useMemo(
-    () => (!inspectionId || !token),
-    [inspectionId, token],
+    () => (!clientId || !inspectionId || !token),
+    [clientId, inspectionId, token],
   );
 
   useEffect(() => {


### PR DESCRIPTION
**Functionalities:**
* [x] Modify the client-id param from single digit to string value
* [x] Show either client app or error message basis on client param


**Here are some scenarios that website will show:**
* It will show default app, if path doesn’t have `?c={client-id}` parameter
* It will show client-app basis on client-id, if path has `?c={client-id}` with **valid** value
* It will show error message, if path has `?c={client-id}` with **invalid** value