### PR TITLE
feat: create vehicle type selection (MN-297)

### DIFF
--- a/src/config/Navigation.js
+++ b/src/config/Navigation.js
@@ -22,6 +22,11 @@ export default function Navigation() {
           title="Monk - Inspection Capture"
         />
         <Stack.Screen
+          name={names.CAPTURE_VEHICLE_SELECTION}
+          component={Screens.CaptureVehicleSelection}
+          title="Monk - Inspection Capture Vehicle Selection"
+        />
+        <Stack.Screen
           name={names.INSPECTION_CREATE}
           component={Screens.InspectionCreate}
           title="Monk - Inspection Create"

--- a/src/contexts/clients/workflows/index.js
+++ b/src/contexts/clients/workflows/index.js
@@ -3,7 +3,7 @@ import Workflows from './workflows';
 
 const ClientWorkflows = {
   [Clients.DEFAULT]: Workflows.DEFAULT,
-  [Clients.CAT]: Workflows.CAPTURE,
+  [Clients.CAT]: Workflows.CAPTURE_VEHICLE_SELECTION,
   [Clients.FASTBACK]: Workflows.DEFAULT,
   [Clients.ALPHA]: Workflows.DEFAULT,
 };

--- a/src/contexts/clients/workflows/workflows.js
+++ b/src/contexts/clients/workflows/workflows.js
@@ -1,6 +1,7 @@
 const Workflows = {
   DEFAULT: 'default',
   CAPTURE: 'capture',
+  CAPTURE_VEHICLE_SELECTION: 'capture vehicle selection',
 };
 
 export default Workflows;

--- a/src/screens/CaptureVehicleSelection/index.js
+++ b/src/screens/CaptureVehicleSelection/index.js
@@ -1,0 +1,158 @@
+import { useMonitoring } from '@monkvision/corejs';
+import { useInterval } from '@monkvision/toolkit';
+import { Container } from '@monkvision/ui';
+import { useFocusEffect, useNavigation, useRoute } from '@react-navigation/native';
+import { LinearGradient } from 'expo-linear-gradient';
+import useSnackbar from 'hooks/useSnackbar';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Text, View, useWindowDimensions } from 'react-native';
+import { Card, List, useTheme } from 'react-native-paper';
+import { useMediaQuery } from 'react-responsive';
+
+import { version } from '@package/json';
+import * as names from 'screens/names';
+import Artwork from '../Landing/Artwork';
+import LanguageSwitch from '../Landing/LanguageSwitch';
+import useGetInspection from '../Landing/useGetInspection';
+import { Clients, Workflows, useClient } from '../../contexts';
+import VehicleType from '../Landing/VehicleType';
+import useUpdateInspectionVehicle from '../Landing/useUpdateInspectionVehicle';
+import useZlibCompression from '../Landing/useZlibCompression';
+import styles from './styles';
+import { ClientParamMap } from '../paramsMap';
+
+export default function CaptureVehicleSelection() {
+  const { colors } = useTheme();
+  const { height } = useWindowDimensions();
+  const { errorHandler } = useMonitoring();
+  const navigation = useNavigation();
+  const { t } = useTranslation();
+  const { Notice } = useSnackbar(true);
+  const { decompress } = useZlibCompression();
+
+  const [vehicleType, setVehicleType] = useState('');
+  const isPortrait = useMediaQuery({ query: '(orientation: portrait)' });
+
+  const route = useRoute();
+
+  const { workflow, setClient } = useClient();
+
+  useEffect(() => {
+    const clientParam = new URLSearchParams(window.location.search)?.get('c');
+    const client = clientParam ? (ClientParamMap[clientParam] ?? Clients.DEFAULT) : Clients.DEFAULT;
+    setClient(client);
+  }, [setClient]);
+
+  const { clientId, inspectionId, token } = useMemo(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const compressedToken = urlParams.get('t');
+    const clientParam = urlParams.get('c');
+
+    return {
+      inspectionId: urlParams.get('i'),
+      vehicleTypeParam: urlParams.get('v'),
+      clientId: clientParam ? ClientParamMap[clientParam] : undefined,
+      token: compressedToken ? decompress(compressedToken) : undefined,
+    };
+  }, []);
+
+  useEffect(() => {
+    if (vehicleType) {
+      navigation.navigate(
+        names.INSPECTION_CREATE,
+        {
+          selectedMod: 'car360',
+          inspectionId,
+          vehicle: { vehicleType },
+        },
+      );
+    }
+  }, [vehicleType]);
+
+  const invalidParams = useMemo(
+    () => (!clientId || !inspectionId || !token),
+    [clientId, inspectionId, token],
+  );
+
+  const shouldFetch = useMemo(() => (
+    workflow === Workflows.CAPTURE ? route.params?.captureComplete : true
+  ), [workflow, route]);
+
+  const getInspection = useGetInspection(inspectionId);
+
+  const invalidToken = useMemo(
+    () => (getInspection?.state?.error?.response?.status === 401),
+    [getInspection],
+  );
+
+  const inspection = useMemo(
+    () => getInspection?.denormalizedEntities[0],
+    [getInspection],
+  );
+
+  const updateInspectionVehicle = useUpdateInspectionVehicle(
+    inspectionId,
+    { vehicleType, vin: inspection?.vehicle?.vin },
+  );
+
+  const start = useCallback(() => {
+    if (inspectionId && getInspection.state.loading !== true && !invalidToken && shouldFetch) {
+      getInspection.start().catch((err) => {
+        errorHandler(err);
+      });
+    }
+  }, [getInspection, shouldFetch]);
+
+  const intervalId = useInterval(start, 1000);
+
+  useFocusEffect(useCallback(() => {
+    start();
+    return () => clearInterval(intervalId);
+  }, [intervalId]));
+
+  const invalidParamsContent = useMemo(() => (
+    <View style={[styles.invalidParamsContainer, { backgroundColor: colors.background }]}>
+      <Text style={[styles.invalidParamsMessage]}>
+        {t(invalidParams ? 'landing.invalidParams' : 'landing.invalidToken')}
+      </Text>
+    </View>
+  ), [invalidParams]);
+
+  return invalidParams || invalidToken ? invalidParamsContent : (
+    <View style={[styles.root, { minHeight: height, backgroundColor: colors.background }]}>
+      <LinearGradient
+        colors={[colors.gradient, colors.background]}
+        style={[styles.background, { height }]}
+      />
+      <Container style={[styles.container, isPortrait ? styles.portrait : {}]}>
+        <View style={[styles.left, isPortrait ? styles.leftPortrait : {}]}>
+          <Artwork />
+        </View>
+        <Card style={[styles.card, styles.right, isPortrait ? styles.rightPortrait : {}]}>
+          <List.Section style={styles.textAlignRight}>
+            <List.Subheader>
+              {t('landing.appVersion')}
+              {': '}
+              {version}
+            </List.Subheader>
+          </List.Section>
+          <List.Section>
+            <List.Subheader>{t('landing.selectVehicle')}</List.Subheader>
+            <VehicleType
+              selected={inspection?.vehicle?.vehicleType || vehicleType}
+              onSelect={(value) => setVehicleType(value)}
+              colors={colors}
+              locallySelected={vehicleType}
+              loading={updateInspectionVehicle.state.loading}
+            />
+          </List.Section>
+          <Card.Actions style={styles.actions}>
+            <LanguageSwitch />
+          </Card.Actions>
+        </Card>
+      </Container>
+      <Notice />
+    </View>
+  );
+}

--- a/src/screens/CaptureVehicleSelection/styles.js
+++ b/src/screens/CaptureVehicleSelection/styles.js
@@ -1,0 +1,115 @@
+import { utils } from '@monkvision/toolkit';
+import { StyleSheet, Dimensions } from 'react-native';
+
+const { width, height } = Dimensions.get('window');
+
+export default StyleSheet.create({
+  root: {
+    position: 'relative',
+  },
+  container: {
+    flex: 1,
+    display: 'flex',
+    justifyContent: 'space-around',
+    flexDirection: 'row',
+    position: 'relative',
+  },
+  portrait: {
+    flex: 1,
+    display: 'flex',
+    justifyContent: 'flex-start',
+    flexDirection: 'column',
+  },
+  background: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+  },
+  left: {
+    flex: 0.75,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    paddingBottom: utils.styles.spacing(2),
+    paddingRight: utils.styles.spacing(2),
+    paddingTop: utils.styles.spacing(4),
+  },
+  leftPortrait: {
+    flex: 'none',
+  },
+  right: {
+    flex: 1.25,
+    display: 'flex',
+  },
+  evenListItem: {
+    elevation: 4,
+  },
+  oddListItem: {
+    elevation: 1,
+  },
+  actions: {
+    justifyContent: 'flex-end',
+    flexWrap: 'wrap',
+  },
+  listLoading: {
+    marginHorizontal: utils.styles.spacing(2),
+  },
+  card: {
+    borderRadius: 0,
+  },
+  // modal
+  modalRoot: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    zIndex: 10,
+    width: '100%',
+    height: '100%',
+  },
+  modalContainer: {
+    position: 'relative',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100%',
+    height: '100%',
+  },
+  modalPlayground: {
+    alignSelf: 'center',
+    zIndex: 10,
+    borderRadius: 8,
+    width: 200,
+    height: 'auto',
+    padding: 4,
+  },
+  modalItem: {
+    borderRadius: 4,
+  },
+  pressOutside: {
+    zIndex: 1,
+    opacity: 0.8,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+  },
+  blur: {
+    width,
+    height,
+  },
+  textAlignRight: {
+    alignItems: 'flex-end',
+  },
+  invalidParamsContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  invalidParamsMessage: {
+    color: '#ffffff',
+    fontSize: 20,
+    textAlign: 'center',
+  },
+});

--- a/src/screens/Landing/index.js
+++ b/src/screens/Landing/index.js
@@ -28,28 +28,12 @@ import useVinModal from './useVinModal';
 import useZlibCompression from './useZlibCompression';
 import VehicleType from './VehicleType';
 import useUpdateInspectionVehicle from './useUpdateInspectionVehicle';
+import { ClientParamMap, VehicleTypeMap } from '../paramsMap';
 
 const ICON_BY_STATUS = {
   NOT_STARTED: 'chevron-right',
   DONE: 'check-bold',
   ERROR: 'alert-octagon',
-};
-
-const ClientParamMap = {
-  d9m: Clients.DEFAULT,
-  pd8: Clients.CAT,
-  '2bd': Clients.FASTBACK,
-  a3o: Clients.ALPHA,
-};
-
-const VehicleTypeMap = {
-  0: 'suv',
-  1: 'cuv',
-  2: 'sedan',
-  3: 'hatchback',
-  4: 'van',
-  5: 'minivan',
-  6: 'pickup',
 };
 
 export default function Landing() {
@@ -81,10 +65,11 @@ export default function Landing() {
     const urlParams = new URLSearchParams(window.location.search);
     const compressedToken = urlParams.get('t');
     const clientParam = urlParams.get('c');
+    const vehicleParam = urlParams.get('v');
 
     return {
       inspectionId: urlParams.get('i'),
-      vehicleTypeParam: urlParams.get('v') ?? 1,
+      vehicleTypeParam: (clientParam === 'pd8') ? vehicleParam : vehicleParam ?? 1,
       clientId: clientParam ? ClientParamMap[clientParam] : undefined,
       token: compressedToken ? decompress(compressedToken) : undefined,
     };
@@ -105,6 +90,19 @@ export default function Landing() {
           vehicle: { vehicleType: VehicleTypeMap[vehicleTypeParam] ?? 'cuv' },
         },
       );
+    } else if (workflow === Workflows.CAPTURE_VEHICLE_SELECTION && !route.params?.captureComplete) {
+      if (vehicleTypeParam && VehicleTypeMap[vehicleTypeParam]) {
+        navigation.navigate(
+          names.INSPECTION_CREATE,
+          {
+            selectedMod: 'car360',
+            inspectionId,
+            vehicle: { vehicleType: VehicleTypeMap[vehicleTypeParam] },
+          },
+        );
+      } else {
+        navigation.navigate(names.CAPTURE_VEHICLE_SELECTION, { inspectionId });
+      }
     }
   }, [workflow, route, navigation, inspectionId, vehicleTypeParam]);
 

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -1,3 +1,4 @@
+export { default as CaptureVehicleSelection } from './CaptureVehicleSelection';
 export { default as InspectionCapture } from './InspectionCapture';
 export { default as InspectionCreate } from './InspectionCreate';
 export { default as InspectionVehicleUpdate } from './InspectionVehicleUpdate';

--- a/src/screens/names.js
+++ b/src/screens/names.js
@@ -1,5 +1,6 @@
 export const INSPECTION_CAPTURE = 'inspectionCapture';
 export const INSPECTION_CREATE = 'inspectionCreate';
+export const CAPTURE_VEHICLE_SELECTION = 'captureVehicleSelection';
 export const INSPECTION_VEHICLE_UPDATE = 'InspectionVehicleUpdate';
 export const INSPECTION_LIST = 'inspectionList';
 export const INSPECTION_PROMPT = 'inspectionPrompt';

--- a/src/screens/paramsMap.js
+++ b/src/screens/paramsMap.js
@@ -1,0 +1,18 @@
+import { Clients } from '../contexts';
+
+export const ClientParamMap = {
+  d9m: Clients.DEFAULT,
+  pd8: Clients.CAT,
+  '2bd': Clients.FASTBACK,
+  a3o: Clients.ALPHA,
+};
+
+export const VehicleTypeMap = {
+  0: 'suv',
+  1: 'cuv',
+  2: 'sedan',
+  3: 'hatchback',
+  4: 'van',
+  5: 'minivan',
+  6: 'pickup',
+};


### PR DESCRIPTION
Added new workflow CAPTURE_VEHICLE_SELECTION for CAT application.
If vehicle type is not provided for CAT, then the user will be redirected to the vehicle type selection screen, else will redirect to the capture screen.