### PR TITLE
Make the changes as per QA feedback

### DIFF
--- a/packages/inspection-report/src/components/CarView360/index.js
+++ b/packages/inspection-report/src/components/CarView360/index.js
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { CarOrientation, VehicleType } from '../../resources';
+import { useOrientation, ORIENTATION_MODE } from '../../hooks';
 import { useCarView360Wireframe, useXMLParser } from './hooks';
 import SVGElementMapper from './SVGElementMapper';
 
@@ -26,6 +27,7 @@ export default function CarView360({
   onPressPill,
 }) {
   const wireframeXML = useCarView360Wireframe({ orientation, vehicleType });
+  const windowOrientation = useOrientation();
   const doc = useXMLParser(wireframeXML);
   const svgElement = useMemo(() => {
     const svg = doc.children[0];
@@ -38,9 +40,13 @@ export default function CarView360({
     () => damages.filter((dmg) => !!dmg.pricing && !!dmg.severity),
     [damages],
   );
+  const maxWidth = useMemo(
+    () => (windowOrientation === ORIENTATION_MODE.Landscape ? '50%' : '100%'),
+    [windowOrientation],
+  );
 
   return (
-    <View style={[styles.container, { width, height }]}>
+    <View style={[styles.container, { width, height, maxWidth }]}>
       <SVGElementMapper
         element={svgElement}
         damages={displayedDamages}

--- a/packages/inspection-report/src/components/DamageReport/DamageManipulator.js
+++ b/packages/inspection-report/src/components/DamageReport/DamageManipulator.js
@@ -172,9 +172,9 @@ export default function DamageManipulator({
                 <Slider
                   style={{ marginRight: 15 }}
                   minimumValue={0}
-                  maximumValue={3000}
+                  maximumValue={1500}
                   lowerLimit={0}
-                  upperLimit={3000}
+                  upperLimit={1500}
                   step={20}
                   disabled={displayMode === DisplayMode.FULL && !editedDamage}
                   value={editedDamage?.pricing ?? 0}

--- a/packages/inspection-report/src/components/DamageReport/DamageReport.js
+++ b/packages/inspection-report/src/components/DamageReport/DamageReport.js
@@ -31,7 +31,7 @@ const styles = StyleSheet.create({
   header: {
     alignSelf: 'stretch',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     paddingTop: 13,
     paddingBottom: 13,
     marginBottom: 16,
@@ -51,6 +51,10 @@ const styles = StyleSheet.create({
   text: {
     color: '#fafafa',
     fontSize: 18,
+  },
+  fileIcon: {
+    position: 'absolute',
+    right: 0,
   },
   title: {
     fontSize: 20,
@@ -170,14 +174,13 @@ export default function DamageReport({
   return (
     <View style={[styles.container]}>
       <View style={[styles.header]}>
-        <IconButton icon="keyboard-backspace" onPress={() => console.log('Back')} />
         <Text style={[styles.text, styles.title]}>{t('damageReport.title')}</Text>
         <IconButton
           icon="file-download"
           onPress={handleDownload}
           disabled={pdfStatus !== PdfStatus.READY}
           color={pdfIconColor}
-          style={[generatePdf ? {} : { opacity: 0 }]}
+          style={[styles.fileIcon, generatePdf ? {} : { opacity: 0 }]}
         />
       </View>
       <View style={[styles.content]}>

--- a/packages/inspection-report/src/components/DamageReport/DamageReport.js
+++ b/packages/inspection-report/src/components/DamageReport/DamageReport.js
@@ -41,12 +41,16 @@ const styles = StyleSheet.create({
     display: 'flex',
     alignSelf: 'stretch',
     marginBottom: 16,
-    overflowY: 'scroll',
+    overflowY: 'hidden',
   },
   tabGroup: {
     flexDirection: 'row',
     justifyContent: 'center',
     marginBottom: 32,
+  },
+  tabContent: {
+    flex: 1,
+    overflowY: 'scroll',
   },
   text: {
     color: '#fafafa',
@@ -217,7 +221,7 @@ export default function DamageReport({
               />
             </TabGroup>
           </View>
-          <View>
+          <View style={[styles.tabContent]}>
             {currentTab === Tabs.OVERVIEW && !isInspectionReady && (
               <View style={[styles.notReadyContainer]}>
                 <Loader texts={[t('damageReport.notReady')]} />

--- a/packages/inspection-report/src/components/DamageReport/Overview/index.js
+++ b/packages/inspection-report/src/components/DamageReport/Overview/index.js
@@ -1,8 +1,7 @@
-import { Loader } from '@monkvision/ui/src';
 import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StyleSheet, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
 
 import { CarOrientation, CommonPropTypes, DamageMode, VehicleType } from '../../../resources';
 import CarView360 from '../../CarView360';
@@ -78,6 +77,15 @@ export default function Overview({
   const damageCounts = useDamageCounts(damages);
   const { t } = useTranslation();
 
+  const pdfBtnDisabledState = useMemo(() => {
+    switch (pdfStatus) {
+      case PdfStatus.READY:
+        return false;
+      default:
+        return true;
+    }
+  }, [pdfStatus]);
+
   const pdfButtonColor = useMemo(() => {
     switch (pdfStatus) {
       case PdfStatus.READY:
@@ -120,11 +128,21 @@ export default function Overview({
               </TouchableOpacity>
               {generatePdf && (
                 <TouchableOpacity
-                  style={[styles.button, { backgroundColor: pdfButtonColor }]}
+                  style={[
+                    styles.button,
+                    {
+                      backgroundColor: pdfButtonColor,
+                      paddingHorizontal: pdfBtnDisabledState ? 65 : 20,
+                    },
+                  ]}
                   onPress={handleDownload}
-                  disabled={pdfStatus !== PdfStatus.READY}
+                  disabled={pdfBtnDisabledState}
                 >
-                  <Text style={[styles.buttonText]}>{ t('damageReport.download') }</Text>
+                  {
+                    pdfBtnDisabledState
+                      ? <ActivityIndicator size="small" color="white" />
+                      : <Text style={[styles.buttonText]}>{ t('damageReport.download') }</Text>
+                  }
                 </TouchableOpacity>
               )}
             </>

--- a/packages/inspection-report/src/components/DamageReport/UpdateDamageModal.js
+++ b/packages/inspection-report/src/components/DamageReport/UpdateDamageModal.js
@@ -92,6 +92,11 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
   },
   damageManipulatorContainer: {
+    flex: 1,
+    alignSelf: 'center',
+    width: '100%',
+    maxWidth: '500px',
+    overflowY: 'scroll',
     paddingHorizontal: 20,
   },
 });

--- a/packages/inspection-report/src/components/DamageReport/hooks/usePdfReport.js
+++ b/packages/inspection-report/src/components/DamageReport/hooks/usePdfReport.js
@@ -45,7 +45,7 @@ export default function usePdfReport({
   const { i18n } = useTranslation();
 
   const pdfRequestPayload = useMemo(() => ({
-    pricing: false,
+    pricing: true,
     customer,
     clientName,
     language: i18n.language?.substring(0, 2) ?? 'en',

--- a/packages/inspection-report/src/hooks/index.js
+++ b/packages/inspection-report/src/hooks/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as useOrientation, ORIENTATION_MODE } from './useOrientation';

--- a/packages/inspection-report/src/hooks/useOrientation.js
+++ b/packages/inspection-report/src/hooks/useOrientation.js
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { Dimensions } from 'react-native';
+
+export const ORIENTATION_MODE = {
+  Portrait: 'portrait',
+  Landscape: 'landscape',
+};
+
+const useOrientation = () => {
+  const [orientation, setOrientation] = useState('');
+
+  useEffect(() => {
+    const handleOrientationChange = ({ window }) => {
+      if (window.height > window.width) {
+        setOrientation(ORIENTATION_MODE.Portrait);
+      } else {
+        setOrientation(ORIENTATION_MODE.Landscape);
+      }
+    };
+
+    handleOrientationChange({ window: Dimensions.get('window') });
+    Dimensions.addEventListener('change', handleOrientationChange);
+    return () => {
+      Dimensions.removeEventListener('change', handleOrientationChange);
+    };
+  }, []);
+
+  return orientation;
+};
+
+export default useOrientation;

--- a/src/screens/Authentication/SignIn/index.js
+++ b/src/screens/Authentication/SignIn/index.js
@@ -69,7 +69,7 @@ export default function SignIn() {
         <Paragraph style={styles.p}>
           {t('signin.success.message')}
         </Paragraph>
-        <Button mode="contained" color={colors.success} style={styles.button} onPress={handleNext}>
+        <Button mode="contained" color={colors.primary} style={styles.button} onPress={handleNext}>
           {t('signin.success.button')}
         </Button>
       </View>


### PR DESCRIPTION
## Done
* In `src/components/DamageReport/hooks/usePdfReport.js` line 48, switch to `pricing: true` in the PDF payload
* Set the pricing slider limit to 1500
* In `src/Screens/Authentication/SignIn/index.js` change the color of the success button from `colors.success` to `colors.primary` and verify that it is blue
* Replace the content of the download report button (the button with the damageReport.download label in `Overview/index.js` with a loader while it is loading (any basic loader will suffice)
* Remove the back-button at the top-left of the screen (in the header)
* Add a padding bottom at the end of the DamageManipulator so that the user can scroll down to the “done” button when the screen is too small (as you can see in the screenshot below). Only add the padding bottom if the screen is too short though!
* Make the app responsive : make it so that the app works well in landscape

