### PR TITLE
feat: add generic webapp monitoring (MN-299)

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -280,6 +280,6 @@ export default {
       palette,
     },
     ...app,
-    ...eas.build.preview.env,
+    ...eas.build.development.env,
   },
 };

--- a/src/contexts/clients/monitoring/alpha.js
+++ b/src/contexts/clients/monitoring/alpha.js
@@ -1,0 +1,13 @@
+import Constants from 'expo-constants';
+import { name, version } from '@package/json';
+
+const alphaConfig = {
+  dsn: Constants.manifest.extra.SENTRY_DSN,
+  environment: Constants.manifest.extra.ENV,
+  debug: Constants.manifest.extra.ENV !== 'production',
+  tracesSampleRate: 0.025,
+  release: `${name}@${version}`,
+  tracingOrigins: ['localhost', 'cna.dev.monk.ai', 'cna-staging.dev.monk.ai', 'cna.preview.monk.ai', 'cna.monk.ai'],
+};
+
+export default alphaConfig;

--- a/src/contexts/clients/monitoring/cat.js
+++ b/src/contexts/clients/monitoring/cat.js
@@ -1,0 +1,13 @@
+import Constants from 'expo-constants';
+import { name, version } from '@package/json';
+
+const catConfig = {
+  dsn: Constants.manifest.extra.SENTRY_DSN,
+  environment: Constants.manifest.extra.ENV,
+  debug: Constants.manifest.extra.ENV !== 'production',
+  tracesSampleRate: 0.025,
+  release: `${name}@${version}`,
+  tracingOrigins: ['localhost', 'cna.dev.monk.ai', 'cna-staging.dev.monk.ai', 'cna.preview.monk.ai', 'cna.monk.ai'],
+};
+
+export default catConfig;

--- a/src/contexts/clients/monitoring/default.js
+++ b/src/contexts/clients/monitoring/default.js
@@ -1,0 +1,13 @@
+import Constants from 'expo-constants';
+import { name, version } from '@package/json';
+
+const defaultConfig = {
+  dsn: Constants.manifest.extra.SENTRY_DSN,
+  environment: Constants.manifest.extra.ENV,
+  debug: Constants.manifest.extra.ENV !== 'production',
+  tracesSampleRate: 0.025,
+  release: `${name}@${version}`,
+  tracingOrigins: ['localhost', 'cna.dev.monk.ai', 'cna-staging.dev.monk.ai', 'cna.preview.monk.ai', 'cna.monk.ai'],
+};
+
+export default defaultConfig;

--- a/src/contexts/clients/monitoring/fastback.js
+++ b/src/contexts/clients/monitoring/fastback.js
@@ -1,0 +1,13 @@
+import Constants from 'expo-constants';
+import { name, version } from '@package/json';
+
+const fastbackConfig = {
+  dsn: Constants.manifest.extra.SENTRY_DSN,
+  environment: Constants.manifest.extra.ENV,
+  debug: Constants.manifest.extra.ENV !== 'production',
+  tracesSampleRate: 0.025,
+  release: `${name}@${version}`,
+  tracingOrigins: ['localhost', 'cna.dev.monk.ai', 'cna-staging.dev.monk.ai', 'cna.preview.monk.ai', 'cna.monk.ai'],
+};
+
+export default fastbackConfig;

--- a/src/contexts/clients/monitoring/index.js
+++ b/src/contexts/clients/monitoring/index.js
@@ -1,0 +1,14 @@
+import Clients from '../clients';
+import defaultConfig from './default';
+import catConfig from './cat';
+import fastbackConfig from './fastback';
+import alphaConfig from './alpha';
+
+const ClientMonitoring = {
+  [Clients.DEFAULT]: defaultConfig,
+  [Clients.CAT]: catConfig,
+  [Clients.FASTBACK]: fastbackConfig,
+  [Clients.ALPHA]: alphaConfig,
+};
+
+export default ClientMonitoring;

--- a/src/main.js
+++ b/src/main.js
@@ -1,32 +1,35 @@
-import React from 'react';
-import { render } from 'react-dom';
+import { MonitoringProvider } from '@monkvision/corejs';
+import App from 'components/App';
 import { registerRootComponent } from 'expo';
-import Constants from 'expo-constants';
+import React, { useEffect } from 'react';
+import { render } from 'react-dom';
 import { Platform } from 'react-native';
 import * as Sentry from 'sentry-expo';
-import { name, version } from '@package/json';
-import App from 'components/App';
+import { ClientProvider, useClient } from './contexts/clients';
 import './i18n';
-import { MonitoringProvider } from '@monkvision/corejs';
-import { ClientProvider } from './contexts/clients';
+import ClientMonitoring from './contexts/clients/monitoring';
 
-const config = {
-  dsn: Constants.manifest.extra.SENTRY_DSN,
-  environment: Constants.manifest.extra.ENV,
-  debug: Constants.manifest.extra.ENV !== 'production',
-  tracesSampleRate: 0.025,
-  release: `${name}@${version}`,
-  tracingOrigins: ['localhost', 'cna.dev.monk.ai', 'cna-staging.dev.monk.ai', 'cna.preview.monk.ai', 'cna.monk.ai'],
-};
+function SentryWrapper() {
+  const { client } = useClient();
+
+  useEffect(() => {
+    console.log('🚀 ~ useEffect ~ client:', client);
+    console.log('🚀 ~ useEffect ~ ClientMonitoring[client]:', ClientMonitoring[client]);
+  }, [client]);
+
+  return (
+    <MonitoringProvider config={ClientMonitoring[client]}>
+      <App />
+    </MonitoringProvider>
+  );
+}
 
 if (Platform.OS === 'web') {
   const container = document.getElementById('root');
   render(
-    <MonitoringProvider config={config}>
-      <ClientProvider>
-        <App />
-      </ClientProvider>
-    </MonitoringProvider>,
+    <ClientProvider>
+      <SentryWrapper />
+    </ClientProvider>,
     container,
   );
 } else {


### PR DESCRIPTION
Add generic configuration to setup Sentry for all the clients