### PR TITLE
fix an issue to add & show labels for added damaged parts in Damage-R…

### DIFF
--- a/packages/camera/src/components/Capture/capture.js
+++ b/packages/camera/src/components/Capture/capture.js
@@ -276,7 +276,7 @@ const Capture = forwardRef(({
     endTour,
   };
   const startUploadAsync = useStartUploadAsync(startUploadAsyncParams);
-  const uploadAdditionalDamage = useUploadAdditionalDamage({ inspectionId });
+  const uploadAdditionalDamage = useUploadAdditionalDamage({ inspectionId, addDamageParts });
 
   const [goPrevSight, goNextSight] = useNavigationBetweenSights({ sights });
 

--- a/packages/camera/src/components/Capture/hooks.js
+++ b/packages/camera/src/components/Capture/hooks.js
@@ -6,6 +6,7 @@ import { manipulateAsync, SaveFormat } from 'expo-image-manipulator';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Platform } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import Actions from '../../actions';
 import Constants from '../../const';
 import log from '../../utils/log';
@@ -304,9 +305,9 @@ export function useStartUploadAsync({
   }, [uploads, inspectionId, sights.state, mapTasksToSights, task, onFinish, endTour]);
 }
 
-export function useUploadAdditionalDamage({
-  inspectionId,
-}) {
+export function useUploadAdditionalDamage({ inspectionId, addDamageParts }) {
+  const { t, i18n } = useTranslation();
+
   return useCallback(async ({ picture, parts }) => {
     if (!inspectionId) {
       throw Error(`Please provide a valid "inspectionId". Got ${inspectionId}.`);
@@ -322,6 +323,15 @@ export function useUploadAdditionalDamage({
         filename,
       };
 
+      const part = addDamageParts[0];
+      const resources = Object.keys(i18n.options.resources);
+      const metadata = {
+        category: 'exterior',
+        label: resources.reduce((accumulator, lng) => {
+          accumulator[lng] = t(`partSelector.parts.${part}`, { lng });
+          return accumulator;
+        }, {}),
+      };
       const json = JSON.stringify({
         acquisition: {
           strategy: 'upload_multipart_form_keys',
@@ -336,6 +346,7 @@ export function useUploadAdditionalDamage({
         tasks: ['damage_detection'],
         image_type: 'close_up',
         additional_data: {
+          ...metadata,
           overlay: undefined,
           createdAt: new Date(),
         },
@@ -375,7 +386,7 @@ export function useUploadAdditionalDamage({
 
       throw err;
     }
-  }, [inspectionId]);
+  }, [inspectionId, addDamageParts]);
 }
 
 /**


### PR DESCRIPTION
## Technical description
Fix an issue by passing `label` data in API's request payload for `Zoomed Damage` image while uploading the images. Thus, it will show the label under `Zoomed Damage` images in `Damage Report › Photos` section.

