### PR TITLE
fix: reset pdf generate api call on error (MN-327)

### DIFF
--- a/packages/inspection-report/src/components/DamageReport/DamageReport.js
+++ b/packages/inspection-report/src/components/DamageReport/DamageReport.js
@@ -182,6 +182,12 @@ export default function DamageReport({
     }
   }, [pdfStatus]);
 
+  useEffect(() => {
+    if (pdfStatus === PdfStatus.ERROR) {
+      setIsEditable(true);
+    }
+  }, [pdfStatus])
+
   return (
     <View style={[styles.container]}>
       <View style={[styles.header]}>

--- a/packages/inspection-report/src/components/DamageReport/hooks/usePdfReport.js
+++ b/packages/inspection-report/src/components/DamageReport/hooks/usePdfReport.js
@@ -65,6 +65,10 @@ export default function usePdfReport({
         console.error('Error while trying to fetch the PDF download URL :', err);
         setPdfStatus(PdfStatus.ERROR);
       }
+
+      setTimeout(() => {
+        setPdfStatus(PdfStatus.NOT_REQUESTED);
+      }, 5000);
     }),
     [inspectionId],
   );

--- a/packages/inspection-report/src/i18n/resources/en.js
+++ b/packages/inspection-report/src/i18n/resources/en.js
@@ -30,7 +30,7 @@ const en = {
       pdfStatus: {
         generating: 'Your PDF report is being generated...',
         ready: 'Your PDF report is ready',
-        error: 'An error occurred during the generation of your PDF report',
+        error: 'An error occurred during the generation of your PDF report. Please try again.',
       },
       modals: {
         validate: {

--- a/packages/inspection-report/src/i18n/resources/fr.js
+++ b/packages/inspection-report/src/i18n/resources/fr.js
@@ -30,7 +30,7 @@ const fr = {
       pdfStatus: {
         generating: 'Génération du rapport PDF en cours...',
         ready: 'Le rapport PDF est prêt',
-        error: 'Une erreur est survenue lors de la génération du rapport PDF',
+        error: 'Une erreur s\'est produite lors de la génération de votre rapport PDF. Veuillez réessayer.',
       },
       modals: {
         validate: {


### PR DESCRIPTION
Reset pdf status to not started if we have any error on generating pdf