### PR TITLE
fix an issue to show the VIN capture sight in capture-tour when user selects VIN task from landing page

### DIFF
--- a/src/screens/InspectionCapture/index.js
+++ b/src/screens/InspectionCapture/index.js
@@ -28,9 +28,9 @@ export default function InspectionCapture() {
   const { colors } = useTheme();
   const { errorHandler } = useMonitoring();
 
-  const { inspectionId, taskName, vehicleType, selectedMode } = route.params;
+  const { inspectionId, sightIds, taskName, vehicleType, selectedMode } = route.params;
   const { client, sights } = useClient();
-  const sightIds = useMemo(() => (sights[vehicleType ?? 'cuv']), [sights, vehicleType]);
+  const newSightIds = useMemo(() => ((taskName === monk.types.TaskName.IMAGES_OCR) ? sightIds : (sights[vehicleType ?? 'cuv'])), [sights, vehicleType]);
 
   const [isFocused, setFocused] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -113,7 +113,7 @@ export default function InspectionCapture() {
 
       try {
         const promises = Object.values(mapTasksToSights)
-          .filter(((taskBySight) => sightIds.includes(taskBySight.id)))
+          .filter(((taskBySight) => newSightIds.includes(taskBySight.id)))
           .map(mapTaskBySightToTasknames)
           .flat()
           .concat([taskName])
@@ -215,7 +215,7 @@ export default function InspectionCapture() {
         task={taskName}
         enableCarCoverage
         mapTasksToSights={mapTasksToSights}
-        sightIds={sightIds}
+        sightIds={newSightIds}
         inspectionId={inspectionId}
         isFocused={isFocused}
         controls={controls}

--- a/src/screens/Landing/index.js
+++ b/src/screens/Landing/index.js
@@ -242,19 +242,27 @@ export default function Landing() {
   }, [handleListItemPress, inspection]);
 
   const start = useCallback(() => {
-    if (inspectionId && getInspection.state.loading !== true && !invalidToken && shouldFetch) {
+    if (inspectionId && getInspection.state.loading !== true
+       && !invalidToken && !allTasksAreCompleted
+       && shouldFetch && route.params?.captureComplete) {
       getInspection.start().catch((err) => {
         errorHandler(err);
       });
     }
-  }, [getInspection, shouldFetch]);
+  }, [
+    inspectionId,
+    allTasksAreCompleted,
+    route.params?.captureComplete,
+    getInspection,
+    shouldFetch,
+  ]);
 
   const intervalId = useInterval(start, 1000);
 
   useFocusEffect(useCallback(() => {
     start();
     return () => clearInterval(intervalId);
-  }, [intervalId]));
+  }, [start, intervalId]));
 
   useEffect(() => {
     if (inspectionId && !allTasksAreCompleted) {
@@ -275,11 +283,6 @@ export default function Landing() {
     ];
   }, [inspection, i18n.language]);
 
-  const isPdfDisabled = useMemo(
-    () => !allTasksAreCompleted || !reportUrl,
-    [allTasksAreCompleted, reportUrl],
-  );
-
   useEffect(() => {
     if (!vehicleType || vehicleType === inspection?.vehicle?.vehicleType
       || !inspectionId || !inspection?.vehicle?.vin) { return; }
@@ -290,6 +293,11 @@ export default function Landing() {
       }
     })();
   }, [vehicleType, inspection?.vehicle?.vehicleType, inspectionId, inspection?.vehicle?.vin]);
+
+  const isPdfDisabled = useMemo(
+    () => !allTasksAreCompleted || !reportUrl,
+    [allTasksAreCompleted, reportUrl],
+  );
 
   const pdfDownloadLeft = useCallback(
     () => (pdfLoading


### PR DESCRIPTION
# Fixes
- [x] Fix an issue about taking the user to capture **VIN** image when user selects **VIN** operation from the Landing page. It was a weird behaviour as it was starting with a capture-tour even for **VIN**.
- [x] Fix an issue to start making the API call for Inspection when either **VIN** or **Capture-Tour** is completed in order to check if all tasks are done.
- [x] Stop making the API calls for Inspection if all tasks are done and then make API call to generate the PDF file
- [x] Fix the workflows for generic web-app and it should work like described in the ticket (https://monkvision.atlassian.net/browse/MN-339)

# Notes
- [x] Used inspection that was created with **IMAGE_OCR** task
- [x] Make sure that the capture-tour includes wheels related sights for a selected car. It will then allow to run both **Damage_Detection** and **Wheel_Analysis** tasks at the end of the capture-tour to change the status for respective tasks