### PR TITLE
MN-333 - Fix to display moderate symbol correctly in iOS

### DIFF
--- a/packages/inspection-report/src/assets/IconSeverityMedium.js
+++ b/packages/inspection-report/src/assets/IconSeverityMedium.js
@@ -10,25 +10,8 @@ export default function IconSeverityMedium(props) {
       fill="none"
       {...props}
     >
-      <Circle cx={10.5} cy={10} r={8.5} stroke="#E1A25B" strokeWidth={3} />
-      <Mask id="smmask" fill="#fff">
-        <Path
-          fillRule="evenodd"
-          d="M10.5 20V0C4.977 0 .5 4.477.5 10s4.477 10 10 10Z"
-          clipRule="evenodd"
-        />
-      </Mask>
-      <Path
-        fill="#E1A25B"
-        fillRule="evenodd"
-        d="M10.5 20V0C4.977 0 .5 4.477.5 10s4.477 10 10 10Z"
-        clipRule="evenodd"
-      />
-      <Path
-        fill="#E1A25B"
-        d="M10.5 20v4h4v-4h-4Zm0-20h4v-4h-4v4Zm4 20V0h-8v20h8Zm-10-10a6 6 0 0 1 6-6v-8c-7.732 0-14 6.268-14 14h8Zm6 6a6 6 0 0 1-6-6h-8c0 7.732 6.268 14 14 14v-8Z"
-        mask="url(#smmask)"
-      />
+      <Circle cx={10} cy={10} r={8.5} stroke="#E1A25B" strokeWidth={3} />
+      <Path d="M10 0 A10 10 0 0 0 10 20 Z" fill="#E1A25B" />
     </Svg>
   );
 }

--- a/packages/inspection-report/src/components/CarView360/hooks/useInnerHTML.js
+++ b/packages/inspection-report/src/components/CarView360/hooks/useInnerHTML.js
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { getPillDamage } from './common';
 import { RepairOperation } from '../../../resources';
-import { useCurrency } from './../../../hooks';
+import { useCurrency } from '../../../hooks';
 
 export default function useInnerHTML({ element, damages, groupId }) {
   const { formateValue } = useCurrency();

--- a/packages/inspection-report/src/components/DamageReport/DamageManipulator.js
+++ b/packages/inspection-report/src/components/DamageReport/DamageManipulator.js
@@ -7,7 +7,7 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { IconSeverity, SeveritiesWithIcon } from '../../assets';
 import { CommonPropTypes, DamageMode, DisplayMode, Severity, RepairOperation } from '../../resources';
 import { TextButton, SwitchButton } from '../common';
-import { useCurrency } from './../../hooks';
+import { useCurrency } from '../../hooks';
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/inspection-report/src/components/DamageReport/DamageReport.js
+++ b/packages/inspection-report/src/components/DamageReport/DamageReport.js
@@ -14,7 +14,7 @@ import TabButton from './TabButton';
 import TabGroup from './TabGroup';
 import UpdateDamageModal from './UpdateDamageModal';
 import UpdateDamagePopUp from './UpdateDamagePopUp';
-import { useCurrency } from './../../hooks';
+import { useCurrency } from '../../hooks';
 
 const styles = StyleSheet.create({
   container: {
@@ -300,8 +300,8 @@ export default function DamageReport({
 }
 
 DamageReport.propTypes = {
+  currencyCharacter: PropTypes.string,
   damageMode: CommonPropTypes.damageMode,
-  currencyCharacter: PropTypes.string.isRequired,
   generatePdf: PropTypes.bool,
   inspectionId: PropTypes.string.isRequired,
   onStartNewInspection: PropTypes.func,
@@ -313,8 +313,8 @@ DamageReport.propTypes = {
 };
 
 DamageReport.defaultProps = {
-  damageMode: DamageMode.ALL,
   currencyCharacter: '€',
+  damageMode: DamageMode.ALL,
   generatePdf: false,
   onStartNewInspection: () => { },
   pdfOptions: undefined,


### PR DESCRIPTION
## Technical description
- [x] Fixed an issue to display Moderate symbol correctly (half filled circle) in Damage-Report section in iOS
- [x] Fixed ESLint issue for import statement and React component's prop details

