### PR TITLE
Prompt a pop-up to show the error message when click on SkipRetake bu…

### DIFF
--- a/src/components/ErrorModal/index.js
+++ b/src/components/ErrorModal/index.js
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
+import { useTheme } from 'react-native-paper';
+
+import styles from './styles';
+
+export default function ErrorModal({ texts, onPress }) {
+  const { colors } = useTheme();
+  const { width } = useWindowDimensions();
+
+  return (
+    <View style={[styles.container]}>
+      <View style={[styles.errorPopup, { width: width - 60 }]}>
+        <Text style={[styles.errorMessage]}>{texts.message}</Text>
+        <View style={[styles.errorButtonsContainer]}>
+          <TouchableOpacity
+            style={[styles.errorButton, { backgroundColor: colors.surface }]}
+            onPress={onPress}
+          >
+            <Text style={[styles.errorButtonText]}>{texts.label}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+ErrorModal.propTypes = {
+  onPress: PropTypes.func,
+  texts: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    message: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+ErrorModal.defaultProps = {
+  onPress: () => {},
+};

--- a/src/components/ErrorModal/styles.js
+++ b/src/components/ErrorModal/styles.js
@@ -1,0 +1,41 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 999,
+    backgroundColor: '#000000BE',
+  },
+  errorPopup: {
+    padding: 25,
+    paddingBottom: 10,
+    borderRadius: 15,
+    flexDirection: 'column',
+    backgroundColor: '#232429',
+  },
+  errorMessage: {
+    color: '#ffffff',
+    fontSize: 16,
+  },
+  errorButtonsContainer: {
+    marginTop: 25,
+    alignSelf: 'stretch',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+  },
+  errorButton: {
+    padding: 10,
+    borderRadius: 4,
+  },
+  errorButtonText: {
+    color: '#ffffff',
+    fontSize: 16,
+  },
+});

--- a/src/i18n/resources/en.js
+++ b/src/i18n/resources/en.js
@@ -127,6 +127,12 @@ const en = {
         on: 'On',
         off: 'Off',
       },
+      skipRetake: {
+        error: {
+          message: 'Sorry, we couldn\'t finish the inspection',
+          label: 'Start New Inspection',
+        },
+      },
       custom: '+',
     },
   },

--- a/src/i18n/resources/fr.js
+++ b/src/i18n/resources/fr.js
@@ -126,6 +126,12 @@ const fr = {
         on: 'Activer',
         off: 'Désactiver',
       },
+      skipRetake: {
+        error: {
+          message: 'Désolé, nous n\'avons pas pu terminer l\'inspection',
+          label: 'Commencer une nouvelle inspection',
+        },
+      },
       custom: '+',
     },
   },

--- a/src/screens/InspectionCapture/index.js
+++ b/src/screens/InspectionCapture/index.js
@@ -10,6 +10,7 @@ import monk, { useMonitoring } from '@monkvision/corejs';
 import { utils } from '@monkvision/toolkit';
 
 import * as names from 'screens/names';
+import ErrorModal from 'components/ErrorModal';
 import mapTasksToSights from './mapTasksToSights';
 import styles from './styles';
 import useSnackbar from '../../hooks/useSnackbar';
@@ -30,6 +31,7 @@ export default function InspectionCapture() {
   const [isFocused, setFocused] = useState(false);
   const [success, setSuccess] = useState(false);
   const [cameraLoading, setCameraLoading] = useState(false);
+  const [errorModal, setErrorModal] = useState(null);
   const { setShowMessage, Notice } = useSnackbar();
   const { isFullscreen, requestFullscreen } = useFullscreen();
 
@@ -89,6 +91,18 @@ export default function InspectionCapture() {
             }).then(({ entities, result }) => {
               dispatch(monk.actions.gotOneTask({ entities, result, inspectionId }));
               resolve(name);
+            }).catch((err) => {
+              errorHandler(err);
+              setErrorModal({
+                texts: {
+                  message: t('capture.skipRetake.error.message'),
+                  label: t('capture.skipRetake.error.label'),
+                },
+                onPress: () => {
+                  setErrorModal(null);
+                  navigation.navigate(names.LANDING);
+                },
+              });
             });
           }));
 
@@ -212,6 +226,12 @@ export default function InspectionCapture() {
         overlayPathStyles={{ strokeWidth: 2 }}
       />
       <Notice />
+      {errorModal && (
+        <ErrorModal
+          texts={errorModal.texts}
+          onPress={errorModal.onPress}
+        />
+      )}
     </View>
   );
 }


### PR DESCRIPTION
## Technical description
- [x] Fix an issue to make `SkipRetake` button functional by prompting a pop-up with an error message when the functionality (any one of the API calls for tasks such as `Damage_Detection` & `Wheel_Analysis`) gets failed

## Tested
- Make `const enableComplianceCheck = true`
- Make one of the tasks between `Damage_Detection` & `Wheel_Analysis` gets failed

