### PR TITLE
export axios instance for client application

### DIFF
--- a/packages/corejs/src/index.ts
+++ b/packages/corejs/src/index.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import * as actions from './actions';
 import config from './config';
 import * as entity from './entities';
@@ -14,6 +15,7 @@ Object.values(slices).forEach((slice) => {
 });
 
 export default {
+  apiClient: axios,
   actions,
   config,
   entity,


### PR DESCRIPTION
<!--- Please request a review from the leader or members from the FE team  -->

## Technical description
`core` package exports instance of axios for client applications in order to use for interceptor & other stuff while making API calls.
