### PR TITLE
Fix retake non compliant Sight slider

### DIFF
--- a/packages/inspection-capture-web/src/PhotoCapture/PhotoCapture.tsx
+++ b/packages/inspection-capture-web/src/PhotoCapture/PhotoCapture.tsx
@@ -203,6 +203,7 @@ export function PhotoCapture({
     mode: addDamageHandle.mode,
     onOpenGallery: handleOpenGallery,
     onSelectSight: sightState.selectSight,
+    onRetakeSight: sightState.retakeSight,
     onAddDamage: addDamageHandle.handleAddDamage,
     onCancelAddDamage: addDamageHandle.handleCancelAddDamage,
     onRetry: sightState.retryLoadingInspection,

--- a/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUD.tsx
+++ b/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUD.tsx
@@ -47,6 +47,10 @@ export interface PhotoCaptureHUDProps extends CameraHUDProps {
    */
   onSelectSight: (sight: Sight) => void;
   /**
+   * Callback called when the user manually select a sight non compliant.
+   */
+  onRetakeSight: (sight: string) => void;
+  /**
    * Callback to be called when the user clicks on the "Add Damage" button.
    */
   onAddDamage: () => void;
@@ -98,6 +102,7 @@ export function PhotoCaptureHUD({
   lastPictureTaken,
   mode,
   onSelectSight,
+  onRetakeSight,
   onAddDamage,
   onCancelAddDamage,
   onOpenGallery,
@@ -138,6 +143,7 @@ export function PhotoCaptureHUD({
           onAddDamage={onAddDamage}
           onCancelAddDamage={onCancelAddDamage}
           onSelectSight={onSelectSight}
+          onRetakeSight={onRetakeSight}
           isLoading={loading.isLoading || handle.isLoading}
           error={loading.error ?? handle.error}
           streamDimensions={handle.dimensions}

--- a/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreview/PhotoCaptureHUDPreview.tsx
+++ b/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreview/PhotoCaptureHUDPreview.tsx
@@ -37,6 +37,10 @@ export interface PhotoCaptureHUDPreviewProps {
    */
   onSelectSight: (sight: Sight) => void;
   /**
+   * Callback called when the user manually select a sight non compliant.
+   */
+  onRetakeSight: (sight: string) => void;
+  /**
    * The dimensions of the Camera video stream.
    */
   streamDimensions: PixelDimensions | null;
@@ -73,6 +77,7 @@ export function PhotoCaptureHUDPreview(params: PhotoCaptureHUDPreviewProps) {
         sights={params.sights}
         selectedSight={params.selectedSight}
         onSelectedSight={params.onSelectSight}
+        onRetakeSight={params.onRetakeSight}
         sightsTaken={params.sightsTaken}
         onAddDamage={params.onAddDamage}
         streamDimensions={params.streamDimensions}

--- a/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/PhotoCaptureHUDPreviewSight.tsx
+++ b/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/PhotoCaptureHUDPreviewSight.tsx
@@ -24,6 +24,10 @@ export interface PhotoCaptureHUDSightPreviewProps {
    */
   onSelectedSight?: (sight: Sight) => void;
   /**
+   * Callback called when the user manually select a sight non compliant.
+   */
+  onRetakeSight?: (sight: string) => void;
+  /**
    * Callback called when the user clicks on the AddDamage button.
    */
   onAddDamage?: () => void;
@@ -55,6 +59,7 @@ export function PhotoCaptureHUDPreviewSight({
   sights,
   selectedSight,
   onSelectedSight = () => {},
+  onRetakeSight = () => {},
   onAddDamage = () => {},
   sightsTaken,
   streamDimensions,
@@ -82,6 +87,7 @@ export function PhotoCaptureHUDPreviewSight({
         selectedSight={selectedSight}
         sightsTaken={sightsTaken}
         onSelectedSight={onSelectedSight}
+        onRetakeSight={onRetakeSight}
         images={images}
       />
     </div>

--- a/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/SightSlider/SightSlider.tsx
+++ b/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/SightSlider/SightSlider.tsx
@@ -26,6 +26,10 @@ export interface SightSliderProps {
    */
   onSelectedSight?: (sight: Sight) => void;
   /**
+   * Callback called when the user manually select a sight non compliant.
+   */
+  onRetakeSight?: (sight: string) => void;
+  /**
    * The current images taken by the user (ignoring retaken pictures etc.).
    */
   images: Image[];
@@ -70,6 +74,7 @@ export function SightSlider({
   selectedSight,
   sightsTaken,
   onSelectedSight = () => {},
+  onRetakeSight = () => {},
   images,
 }: SightSliderProps) {
   const items = useSightSliderItems(sights, images);
@@ -89,7 +94,9 @@ export function SightSlider({
           label={label(sight)}
           isSelected={sight === selectedSight}
           status={status}
-          onClick={() => onSelectedSight(sight)}
+          onClick={() =>
+            status === ImageStatus.NOT_COMPLIANT ? onRetakeSight(sight.id) : onSelectedSight(sight)
+          }
         />
       ))}
     </div>

--- a/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUD.test.tsx
+++ b/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUD.test.tsx
@@ -47,6 +47,7 @@ function createProps(): PhotoCaptureHUDProps {
     mode: PhotoCaptureMode.SIGHT,
     loading: { isLoading: false, error: null } as unknown as LoadingState,
     onSelectSight: jest.fn(),
+    onRetakeSight: jest.fn(),
     onAddDamage: jest.fn(),
     onCancelAddDamage: jest.fn(),
     onRetry: jest.fn(),

--- a/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreview.test.tsx
+++ b/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreview.test.tsx
@@ -39,6 +39,7 @@ function createProps(): PhotoCaptureHUDPreviewProps {
     onAddDamage: jest.fn(),
     onCancelAddDamage: jest.fn(),
     onSelectSight: jest.fn(),
+    onRetakeSight: jest.fn(),
     streamDimensions: { height: 1234, width: 45678 },
     isLoading: false,
     error: null,

--- a/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/SightSlider/SightSlider.test.tsx
+++ b/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/SightSlider/SightSlider.test.tsx
@@ -29,6 +29,7 @@ function createProps(): SightSliderProps {
     selectedSight: captureSights[2],
     sightsTaken: [captureSights[0], captureSights[1]],
     onSelectedSight: jest.fn(),
+    onRetakeSight: jest.fn(),
     images: [
       { additionalData: { sight_id: 'test-sight-1' }, status: ImageStatus.NOT_COMPLIANT },
       { additionalData: { sight_id: 'test-sight-2' }, status: ImageStatus.SUCCESS },
@@ -60,7 +61,35 @@ describe('SightSlider component', () => {
       );
       expect(typeof buttonProps.onClick).toBe('function');
       buttonProps.onClick?.();
+      if (
+        props.images.find((image) => image.additionalData?.sight_id === sight.id)?.status ===
+        ImageStatus.NOT_COMPLIANT
+      ) {
+        return;
+      }
       expect(props.onSelectedSight).toHaveBeenCalledWith(sight);
+    });
+
+    props.sights.forEach((sight) => {
+      (props.onSelectedSight as jest.Mock).mockClear();
+      const buttonProps = (SightSliderButton as unknown as jest.Mock).mock.calls.find(
+        (args) => args[0].label === sight.id,
+      )?.[0] as SightSliderButtonProps & { key: string };
+
+      expect(buttonProps).toBeDefined();
+      expect(buttonProps.isSelected).toEqual(props.selectedSight === sight);
+      expect(buttonProps.status).toEqual(
+        props.images.find((image) => image.additionalData?.sight_id === sight.id)?.status,
+      );
+      expect(typeof buttonProps.onClick).toBe('function');
+      buttonProps.onClick?.();
+      if (
+        props.images.find((image) => image.additionalData?.sight_id === sight.id)?.status !==
+        ImageStatus.NOT_COMPLIANT
+      ) {
+        return;
+      }
+      expect(props.onRetakeSight).toHaveBeenCalledWith(sight.id);
     });
 
     unmount();


### PR DESCRIPTION
## Overview
<!-- Replace XXX with the ticket number in both the text and the link below -->
<!-- Or remove the line if there are no corresponding ticket -->
Jira Ticket Reference : [MN-520](https://acvauctions.atlassian.net/browse/MN-520)

<!-- Provide a small description of this PR and the feature it implements -->
Fix onRetakeSIght callback for non compliant sight instead of onSelectedSight.

## Checklist before requesting a review
<!-- Make sure that all the items below are checked before requesting a review -->

- [x] I have updated the unit tests based on the changes I made
- [x] I have updated the docs (TSDoc / README / global doc) to reflect my changes
- [x] I have performed self-QA of my feature by testing the apps and packages and made sure that :
  - No regression or new bug has occurred
  - The acceptance criteria listed in the ticket are met
  - **Self-QA was made on both desktop and mobile**


[MN-520]: https://acvauctions.atlassian.net/browse/MN-520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ