### PR TITLE
Fix Refresh in PhotoCapture

### DIFF
--- a/packages/common-ui-web/src/components/ImageDetailedView/ImageDetailedViewOverlay/ImageDetailedViewOverlay.tsx
+++ b/packages/common-ui-web/src/components/ImageDetailedView/ImageDetailedViewOverlay/ImageDetailedViewOverlay.tsx
@@ -2,8 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useObjectTranslation } from '@monkvision/common';
 import {
   ImageDetailedViewOverlayProps,
-  isComplianceContainerDisplayed,
-  useComplianceLabels,
+  useRetakeOverlay,
   useImageDetailedViewOverlayStyles,
   useImageLabelIcon,
 } from './hooks';
@@ -14,7 +13,7 @@ export function ImageDetailedViewOverlay(props: ImageDetailedViewOverlayProps) {
   const { t } = useTranslation();
   const { tObj } = useObjectTranslation();
   const labelIcon = useImageLabelIcon(props);
-  const complianceLabels = useComplianceLabels(props);
+  const retakeOverlay = useRetakeOverlay(props);
   const {
     mainContainerStyle,
     overlayDisplayStyle,
@@ -32,25 +31,27 @@ export function ImageDetailedViewOverlay(props: ImageDetailedViewOverlayProps) {
   return (
     <div style={mainContainerStyle}>
       <div style={overlayDisplayStyle}>
-        {isComplianceContainerDisplayed(props) && (
-          <div style={complianceContainerStyle}>
-            <div style={complianceMessageContainerStyle}>
-              <Icon icon='error' primaryColor='alert' size={complianceIcon.size} />
-              <div style={complianceMessageStyle}>
-                <div style={complianceTitleStyle}>{complianceLabels?.title}</div>
-                <div style={complianceDescriptionStyle}>{complianceLabels?.description}</div>
-              </div>
+        <div style={complianceContainerStyle}>
+          <div style={complianceMessageContainerStyle}>
+            <Icon
+              icon={retakeOverlay.icon}
+              primaryColor={retakeOverlay.iconColor}
+              size={complianceIcon.size}
+            />
+            <div style={complianceMessageStyle}>
+              <div style={complianceTitleStyle}>{retakeOverlay.title}</div>
+              <div style={complianceDescriptionStyle}>{retakeOverlay.description}</div>
             </div>
-            <Button
-              style={complianceRetakeButton.style}
-              size={complianceRetakeButton.size}
-              primaryColor='alert'
-              onClick={props.onRetake}
-            >
-              {t('retake')}
-            </Button>
           </div>
-        )}
+          <Button
+            style={complianceRetakeButton.style}
+            size={complianceRetakeButton.size}
+            primaryColor={retakeOverlay.buttonColor}
+            onClick={props.onRetake}
+          >
+            {t('retake')}
+          </Button>
+        </div>
         {props.image.label && (
           <div style={imageLabelStyle}>
             {labelIcon && (

--- a/packages/common-ui-web/src/components/InspectionGallery/InspectionGallery.tsx
+++ b/packages/common-ui-web/src/components/InspectionGallery/InspectionGallery.tsx
@@ -59,10 +59,10 @@ export const InspectionGallery = i18nWrap((props: InspectionGalleryProps) => {
   };
 
   const handleRetakeImage = (image: Image | null) => {
-    if (props.captureMode && image?.additionalData?.sight_id) {
+    if (props.captureMode && image?.sightId) {
       props.onNavigateToCapture?.({
         reason: NavigateToCaptureReason.RETAKE_PICTURE,
-        sightId: image?.additionalData.sight_id,
+        sightId: image.sightId,
       });
     } else if (props.captureMode && image?.type === ImageType.CLOSE_UP) {
       props.onNavigateToCapture?.({

--- a/packages/common-ui-web/src/components/InspectionGallery/hooks/useInspectionGalleryItems.ts
+++ b/packages/common-ui-web/src/components/InspectionGallery/hooks/useInspectionGalleryItems.ts
@@ -11,7 +11,7 @@ function getSightSortIndex(item: InspectionGalleryItem, inspectionSights?: Sight
   if (item.isAddDamage) {
     return defaultIndex + 1;
   }
-  const sightId = item.isTaken ? item.image.additionalData?.sight_id : item.sightId;
+  const sightId = item.isTaken ? item.image.sightId : item.sightId;
   if (!sightId) {
     return defaultIndex;
   }
@@ -66,10 +66,7 @@ function getItems(
   inspectionSights?.forEach((sight) => {
     if (
       captureMode &&
-      !items.find(
-        (item) =>
-          !item.isAddDamage && item.isTaken && item.image.additionalData?.sight_id === sight.id,
-      )
+      !items.find((item) => !item.isAddDamage && item.isTaken && item.image.sightId === sight.id)
     ) {
       items.push({ isTaken: false, isAddDamage: false, sightId: sight.id });
     }

--- a/packages/common-ui-web/test/components/InspectionGallery/hooks/useInspectionGalleryItems.test.ts
+++ b/packages/common-ui-web/test/components/InspectionGallery/hooks/useInspectionGalleryItems.test.ts
@@ -31,7 +31,7 @@ describe('useInspectionGalleryItems hook', () => {
       {
         id: 'image-1',
         inspectionId: initialProps.inspectionId,
-        additionalData: { sight_id: 'test-sight-2' },
+        sightId: 'test-sight-2',
         status: ImageStatus.SUCCESS,
       } as unknown as Image,
       {
@@ -61,7 +61,7 @@ describe('useInspectionGalleryItems hook', () => {
       {
         id: 'image-1',
         inspectionId: initialProps.inspectionId,
-        additionalData: { sight_id: 'test-sight-1' },
+        sightId: 'test-sight-1',
         status: ImageStatus.SUCCESS,
       } as unknown as Image,
       {
@@ -72,7 +72,7 @@ describe('useInspectionGalleryItems hook', () => {
       {
         id: 'image-3',
         inspectionId: initialProps.inspectionId,
-        additionalData: { sight_id: 'test-sight-3' },
+        sightId: 'test-sight-3',
         status: ImageStatus.SUCCESS,
       } as unknown as Image,
     );
@@ -107,7 +107,7 @@ describe('useInspectionGalleryItems hook', () => {
       {
         id: 'image-1',
         inspectionId: initialProps.inspectionId,
-        additionalData: { sight_id: 'test-sight-1' },
+        sightId: 'test-sight-1',
         status: ImageStatus.SUCCESS,
       } as unknown as Image,
       {
@@ -118,7 +118,7 @@ describe('useInspectionGalleryItems hook', () => {
       {
         id: 'image-3',
         inspectionId: initialProps.inspectionId,
-        additionalData: { sight_id: 'test-sight-3' },
+        sightId: 'test-sight-3',
         status: ImageStatus.NOT_COMPLIANT,
       } as unknown as Image,
     );
@@ -144,17 +144,17 @@ describe('useInspectionGalleryItems hook', () => {
       {
         id: 'image-1',
         inspectionId: initialProps.inspectionId,
-        additionalData: { sight_id: 'test-sight-1' },
+        sightId: 'test-sight-1',
       } as unknown as Image,
       {
         id: 'image-2',
         inspectionId: initialProps.inspectionId,
-        additionalData: { sight_id: 'test-sight-2' },
+        sightId: 'test-sight-2',
       } as unknown as Image,
       {
         id: 'image-3',
         inspectionId: initialProps.inspectionId,
-        additionalData: { sight_id: 'test-sight-3' },
+        sightId: 'test-sight-3',
       } as unknown as Image,
     );
     (useMonkState as jest.Mock).mockImplementationOnce(() => ({ state }));
@@ -187,17 +187,20 @@ describe('useInspectionGalleryItems hook', () => {
       {
         id: 'image-1',
         inspectionId: initialProps.inspectionId,
-        additionalData: { sight_id: 'test-sight-1', created_at: '2020-01-01T01:01:01.001Z' },
+        sightId: 'test-sight-1',
+        createdAt: Date.parse('2020-01-01T01:01:01.001Z'),
       } as unknown as Image,
       {
         id: 'image-2',
         inspectionId: initialProps.inspectionId,
-        additionalData: { sight_id: 'test-sight-1', created_at: '1999-01-01T01:01:01.001Z' },
+        sightId: 'test-sight-1',
+        createdAt: Date.parse('1999-01-01T01:01:01.001Z'),
       } as unknown as Image,
       {
         id: 'image-3',
         inspectionId: initialProps.inspectionId,
-        additionalData: { sight_id: 'test-sight-1', created_at: '2023-01-01T01:01:01.001Z' },
+        sightId: 'test-sight-1',
+        createdAt: Date.parse('2023-01-01T01:01:01.001Z'),
       } as unknown as Image,
     );
     (useMonkState as jest.Mock).mockImplementationOnce(() => ({ state }));
@@ -221,12 +224,14 @@ describe('useInspectionGalleryItems hook', () => {
       {
         id: 'image-1',
         inspectionId: initialProps.inspectionId,
-        additionalData: { sight_id: 'test-sight-1', created_at: '2020-01-01T01:01:01.001Z' },
+        sightId: 'test-sight-1',
+        createdAt: Date.parse('2020-01-01T01:01:01.001Z'),
       } as unknown as Image,
       {
         id: 'image-2',
         inspectionId: initialProps.inspectionId,
-        additionalData: { sight_id: 'test-sight-1', created_at: '1999-01-01T01:01:01.001Z' },
+        sightId: 'test-sight-1',
+        createdAt: Date.parse('1999-01-01T01:01:01.001Z'),
       } as unknown as Image,
     );
     (useMonkState as jest.Mock).mockImplementationOnce(() => ({ state }));

--- a/packages/common/src/i18n/translations/image.ts
+++ b/packages/common/src/i18n/translations/image.ts
@@ -54,10 +54,10 @@ export const imageStatusLabels: Record<ImageStatus, ImageLabels> = {
       nl: 'Succes',
     },
     description: {
-      en: 'This image was uploaded successfully.',
-      fr: "L'image a bien été uploadée.",
-      de: 'Dieses Bild wurde erfolgreich hochgeladen.',
-      nl: 'Deze afbeelding is succesvol geüpload.',
+      en: 'This image seems good, but you can still retake it if you want.',
+      fr: 'Cette image paraît bonne, mais vous pouvez quand-même la reprendre si besoin.',
+      de: 'Dieses Bild scheint gut zu sein, aber Sie können es noch einmal aufnehmen, wenn Sie wollen.',
+      nl: 'Dit beeld lijkt goed, maar je kunt het nog steeds opnieuw maken als je wilt.',
     },
   },
   [ImageStatus.UPLOAD_FAILED]: {

--- a/packages/common/src/state/actions/createdOneImage.ts
+++ b/packages/common/src/state/actions/createdOneImage.ts
@@ -64,7 +64,7 @@ export function createdOneImage(state: MonkState, action: MonkCreatedOneImageAct
   }
   return {
     ...state,
-    inspections,
-    images,
+    inspections: [...inspections],
+    images: [...images],
   };
 }

--- a/packages/common/src/state/actions/gotOneInspection.ts
+++ b/packages/common/src/state/actions/gotOneInspection.ts
@@ -31,6 +31,7 @@ export function gotOneInspection(state: MonkState, action: MonkGotOneInspectionA
   const newState = { ...state };
   Object.keys(state).forEach((key: string) => {
     const entityKey = key as keyof MonkState;
+    newState[entityKey] = [...newState[entityKey]] as any[];
     action.payload[entityKey]?.forEach((payloadEntity) => {
       const newEntityIndex = state[entityKey].findIndex(
         (newEntity) => newEntity.id === payloadEntity.id,

--- a/packages/common/src/state/actions/updatedManyTasks.ts
+++ b/packages/common/src/state/actions/updatedManyTasks.ts
@@ -45,6 +45,6 @@ export function updatedManyTasks(state: MonkState, action: MonkUpdatedManyTasksA
   });
   return {
     ...state,
-    tasks,
+    tasks: [...tasks],
   };
 }

--- a/packages/common/src/utils/state.utils.ts
+++ b/packages/common/src/utils/state.utils.ts
@@ -18,17 +18,13 @@ export function getInspectionImages(
   }
   const filteredRetakes: Image[] = [];
   inspectionImages.forEach((image) => {
-    if (image.additionalData?.sight_id) {
-      const index = filteredRetakes.findIndex(
-        (i) => i.additionalData?.sight_id === image.additionalData?.sight_id,
-      );
+    if (image.sightId) {
+      const index = filteredRetakes.findIndex((i) => i.sightId === image.sightId);
       if (index >= 0) {
-        const imageDateISO = image.additionalData?.created_at;
-        const alreadyExistingImageDateISO = filteredRetakes[index].additionalData?.created_at;
         if (
-          alreadyExistingImageDateISO &&
-          imageDateISO &&
-          new Date(imageDateISO) > new Date(alreadyExistingImageDateISO)
+          image.createdAt &&
+          filteredRetakes[index].createdAt &&
+          image.createdAt > (filteredRetakes[index].createdAt as number)
         ) {
           filteredRetakes[index] = image;
         }

--- a/packages/common/test/utils/state.utils.test.ts
+++ b/packages/common/test/utils/state.utils.test.ts
@@ -44,44 +44,34 @@ describe('State utils', () => {
         {
           id: 'test-2',
           inspectionId,
-          additionalData: {
-            sight_id: 'sight-1',
-            created_at: Date.parse('1998-01-01T01:01:01.001Z'),
-          },
+          sightId: 'sight-1',
+          createdAt: Date.parse('1998-01-01T01:01:01.001Z'),
         },
         {
           id: 'test-3',
           inspectionId,
-          additionalData: {
-            sight_id: 'sight-1',
-            created_at: Date.parse('2020-01-01T01:01:01.001Z'),
-          },
+          sightId: 'sight-1',
+          createdAt: Date.parse('2020-01-01T01:01:01.001Z'),
         },
         {
           id: 'test-4',
           inspectionId,
-          additionalData: {
-            sight_id: 'sight-1',
-            created_at: Date.parse('2024-01-01T01:01:01.001Z'),
-          },
+          sightId: 'sight-1',
+          createdAt: Date.parse('2024-01-01T01:01:01.001Z'),
         },
         { id: 'test-5', inspectionId },
         { id: 'test-6', inspectionId },
         {
           id: 'test-7',
           inspectionId,
-          additionalData: {
-            sight_id: 'sight-2',
-            created_at: Date.parse('2024-01-01T01:01:01.001Z'),
-          },
+          sightId: 'sight-2',
+          createdAt: Date.parse('2024-01-01T01:01:01.001Z'),
         },
         {
           id: 'test-8',
           inspectionId,
-          additionalData: {
-            sight_id: 'sight-2',
-            created_at: Date.parse('1998-01-01T01:01:01.001Z'),
-          },
+          sightId: 'sight-2',
+          createdAt: Date.parse('1998-01-01T01:01:01.001Z'),
         },
       ] as Image[];
       const inspectionImages = getInspectionImages(inspectionId, images, true);
@@ -89,10 +79,8 @@ describe('State utils', () => {
       expect(inspectionImages).toContainEqual({
         id: 'test-4',
         inspectionId,
-        additionalData: {
-          sight_id: 'sight-1',
-          created_at: Date.parse('2024-01-01T01:01:01.001Z'),
-        },
+        sightId: 'sight-1',
+        createdAt: Date.parse('2024-01-01T01:01:01.001Z'),
       });
       expect(inspectionImages).toContainEqual({
         id: 'test-5',
@@ -105,10 +93,8 @@ describe('State utils', () => {
       expect(inspectionImages).toContainEqual({
         id: 'test-7',
         inspectionId,
-        additionalData: {
-          sight_id: 'sight-2',
-          created_at: Date.parse('2024-01-01T01:01:01.001Z'),
-        },
+        sightId: 'sight-2',
+        createdAt: Date.parse('2024-01-01T01:01:01.001Z'),
       });
     });
   });

--- a/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/SightSlider/SightSlider.tsx
+++ b/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/SightSlider/SightSlider.tsx
@@ -58,7 +58,7 @@ function useSightSliderItems(sights: Sight[], images: Image[]): SightSliderItem[
     () =>
       sights.map((sight) => ({
         sight,
-        status: images.find((image) => image.additionalData?.sight_id === sight.id)?.status,
+        status: images.find((image) => image.sightId === sight.id)?.status,
       })),
     [sights, images],
   );

--- a/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/SightSlider/SightSliderButton.tsx
+++ b/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/SightSlider/SightSliderButton.tsx
@@ -59,6 +59,7 @@ function useSliderStyle({
   }
   if (isSelected) {
     sliderStyle.primaryColor = 'primary';
+    sliderStyle.disabled = false;
   }
   return sliderStyle;
 }

--- a/packages/inspection-capture-web/src/PhotoCapture/hooks/usePhotoCaptureSightState.ts
+++ b/packages/inspection-capture-web/src/PhotoCapture/hooks/usePhotoCaptureSightState.ts
@@ -146,10 +146,8 @@ function getSightsTaken(
 ): Sight[] {
   return uniq(
     response.entities.images
-      ?.filter(
-        (image: Image) => image.inspectionId === inspectionId && image.additionalData?.['sight_id'],
-      )
-      .map((image: Image) => sights[image.additionalData?.['sight_id'] as string]) ?? [],
+      ?.filter((image: Image) => image.inspectionId === inspectionId && image.sightId)
+      .map((image: Image) => sights[image.sightId as string]) ?? [],
   );
 }
 
@@ -209,7 +207,7 @@ export function usePhotoCaptureSightState({
           .map((s) => ({
             sight: s,
             image: getInspectionImages(inspectionId, state.images, true).find(
-              (i) => i.inspectionId === inspectionId && i.additionalData?.sight_id === s.id,
+              (i) => i.inspectionId === inspectionId && i.sightId === s.id,
             ),
           }))
           .filter(

--- a/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUD.test.tsx
+++ b/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUD.test.tsx
@@ -60,9 +60,7 @@ function createProps(): PhotoCaptureHUDProps {
       dimensions: { height: 2, width: 4 },
     } as unknown as CameraHandle,
     cameraPreview: <div data-testid={cameraTestId}></div>,
-    images: [
-      { additionalData: { sight_id: 'test-sight-1' }, status: ImageStatus.NOT_COMPLIANT },
-    ] as Image[],
+    images: [{ sightId: 'test-sight-1', status: ImageStatus.NOT_COMPLIANT }] as Image[],
   };
 }
 

--- a/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreview.test.tsx
+++ b/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreview.test.tsx
@@ -43,9 +43,7 @@ function createProps(): PhotoCaptureHUDPreviewProps {
     streamDimensions: { height: 1234, width: 45678 },
     isLoading: false,
     error: null,
-    images: [
-      { additionalData: { sight_id: 'test-sight-1' }, status: ImageStatus.NOT_COMPLIANT },
-    ] as Image[],
+    images: [{ sightId: 'test-sight-1', status: ImageStatus.NOT_COMPLIANT }] as Image[],
   };
 }
 

--- a/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/PhotoCaptureHUDPreviewSight.test.tsx
+++ b/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/PhotoCaptureHUDPreviewSight.test.tsx
@@ -44,8 +44,8 @@ function createProps(): PhotoCaptureHUDSightPreviewProps {
     onAddDamage: jest.fn(),
     streamDimensions: { width: 4563, height: 992 },
     images: [
-      { additionalData: { sight_id: 'test-sight-1' }, status: ImageStatus.NOT_COMPLIANT },
-      { additionalData: { sight_id: 'test-sight-2' }, status: ImageStatus.SUCCESS },
+      { sightId: 'test-sight-1', status: ImageStatus.NOT_COMPLIANT },
+      { sightId: 'test-sight-2', status: ImageStatus.SUCCESS },
     ] as Image[],
   };
 }

--- a/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/SightSlider/SightSlider.test.tsx
+++ b/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/SightSlider/SightSlider.test.tsx
@@ -31,8 +31,8 @@ function createProps(): SightSliderProps {
     onSelectedSight: jest.fn(),
     onRetakeSight: jest.fn(),
     images: [
-      { additionalData: { sight_id: 'test-sight-1' }, status: ImageStatus.NOT_COMPLIANT },
-      { additionalData: { sight_id: 'test-sight-2' }, status: ImageStatus.SUCCESS },
+      { sightId: 'test-sight-1', status: ImageStatus.NOT_COMPLIANT },
+      { sightId: 'test-sight-2', status: ImageStatus.SUCCESS },
     ] as Image[],
   };
 }
@@ -57,12 +57,12 @@ describe('SightSlider component', () => {
       expect(buttonProps).toBeDefined();
       expect(buttonProps.isSelected).toEqual(props.selectedSight === sight);
       expect(buttonProps.status).toEqual(
-        props.images.find((image) => image.additionalData?.sight_id === sight.id)?.status,
+        props.images.find((image) => image.sightId === sight.id)?.status,
       );
       expect(typeof buttonProps.onClick).toBe('function');
       buttonProps.onClick?.();
       if (
-        props.images.find((image) => image.additionalData?.sight_id === sight.id)?.status ===
+        props.images.find((image) => image.sightId === sight.id)?.status ===
         ImageStatus.NOT_COMPLIANT
       ) {
         return;
@@ -79,12 +79,12 @@ describe('SightSlider component', () => {
       expect(buttonProps).toBeDefined();
       expect(buttonProps.isSelected).toEqual(props.selectedSight === sight);
       expect(buttonProps.status).toEqual(
-        props.images.find((image) => image.additionalData?.sight_id === sight.id)?.status,
+        props.images.find((image) => image.sightId === sight.id)?.status,
       );
       expect(typeof buttonProps.onClick).toBe('function');
       buttonProps.onClick?.();
       if (
-        props.images.find((image) => image.additionalData?.sight_id === sight.id)?.status !==
+        props.images.find((image) => image.sightId === sight.id)?.status !==
         ImageStatus.NOT_COMPLIANT
       ) {
         return;

--- a/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/SightSlider/SightSliderButton.test.tsx
+++ b/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDPreviewSight/SightSlider/SightSliderButton.test.tsx
@@ -56,4 +56,12 @@ describe('SightSliderButton component', () => {
       unmount();
     });
   });
+
+  it('should not be disabled if selected', () => {
+    const { unmount } = render(<SightSliderButton status={ImageStatus.SUCCESS} isSelected />);
+
+    expectPropsOnChildMock(Button, { disabled: false });
+
+    unmount();
+  });
 });

--- a/packages/inspection-capture-web/test/PhotoCapture/hooks/usePhotoCaptureImages.test.ts
+++ b/packages/inspection-capture-web/test/PhotoCapture/hooks/usePhotoCaptureImages.test.ts
@@ -11,6 +11,10 @@ import { renderHook } from '@testing-library/react-hooks';
 import { getInspectionImages, useMonkState } from '@monkvision/common';
 
 describe('usePhotoCaptureImages hook', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should return the images of the inspection using the getInspectionImages function', () => {
     const inspectionId = 'test-inspection-id-test';
     const { result, unmount } = renderHook(usePhotoCaptureImages, { initialProps: inspectionId });
@@ -18,6 +22,49 @@ describe('usePhotoCaptureImages hook', () => {
     expect(useMonkState).toHaveBeenCalled();
     expect(getInspectionImages).toHaveBeenCalledWith(inspectionId, stateMock.images, true);
     expect(result.current).toEqual(inspectionImagesMock);
+
+    unmount();
+  });
+
+  it('should re-calculate the images of the inspection every time the state images change', () => {
+    (getInspectionImages as jest.Mock).mockImplementation(() => [{ id: 'test-hello-1' }]);
+    (useMonkState as jest.Mock).mockImplementation(() => ({
+      state: { images: [{ id: 'test-1' }] },
+    }));
+    const inspectionId = 'test-inspection-id-test';
+    const { result, rerender, unmount } = renderHook(usePhotoCaptureImages, {
+      initialProps: inspectionId,
+    });
+
+    const newImages = [{ id: 'test-hello-2' }];
+    (getInspectionImages as jest.Mock).mockImplementation(() => newImages);
+    (useMonkState as jest.Mock).mockImplementation(() => ({
+      state: { images: [{ id: 'test-2' }] },
+    }));
+    rerender();
+    expect(result.current).toEqual(newImages);
+
+    unmount();
+  });
+
+  it('should not re-calculate the images of the inspection if other elements of the state change', () => {
+    const initialInspectionImages = [{ id: 'test-hello-1' }];
+    (getInspectionImages as jest.Mock).mockImplementation(() => initialInspectionImages);
+    const images = [{ id: 'test-1' }];
+    (useMonkState as jest.Mock).mockImplementation(() => ({
+      state: { images, inspections: [{ id: 'test-inspection-1' }] },
+    }));
+    const inspectionId = 'test-inspection-id-test';
+    const { result, rerender, unmount } = renderHook(usePhotoCaptureImages, {
+      initialProps: inspectionId,
+    });
+
+    (getInspectionImages as jest.Mock).mockImplementation(() => [{ id: 'test-hello-2' }]);
+    (useMonkState as jest.Mock).mockImplementation(() => ({
+      state: { images, inspections: [{ id: 'test-inspection-2' }] },
+    }));
+    rerender();
+    expect(result.current).toEqual(initialInspectionImages);
 
     unmount();
   });

--- a/packages/inspection-capture-web/test/PhotoCapture/hooks/usePhotoCaptureSightState.test.ts
+++ b/packages/inspection-capture-web/test/PhotoCapture/hooks/usePhotoCaptureSightState.test.ts
@@ -52,7 +52,8 @@ function mockGetInspectionResponse(
   takenSights.forEach((sight, index) => {
     apiResponse.entities.images.push({
       inspectionId,
-      additionalData: { sight_id: sight.id, created_at: '2020-01-01T01:01:01.001Z' },
+      sightId: sight.id,
+      createdAt: Date.parse('2020-01-01T01:01:01.001Z'),
       path: `test-path-${index}`,
       mimetype: `test-mimetype-${index}`,
       width: index * 2000,
@@ -61,7 +62,8 @@ function mockGetInspectionResponse(
     } as Image);
     apiResponse.entities.images.push({
       inspectionId,
-      additionalData: { sight_id: sight.id, created_at: '1998-01-01T01:01:01.001Z' },
+      sightId: sight.id,
+      createdAt: Date.parse('1998-01-01T01:01:01.001Z'),
       path: `test-path-old-${index}`,
       mimetype: `test-mimetype-old-${index}`,
       width: index * 4000,

--- a/packages/inspection-capture-web/test/PhotoCapture/hooks/usePhotoCaptureSightState.test.ts
+++ b/packages/inspection-capture-web/test/PhotoCapture/hooks/usePhotoCaptureSightState.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { LoadingState, useAsyncEffect } from '@monkvision/common';
-import { ComplianceIssue, Sight, TaskName } from '@monkvision/types';
+import { LoadingState, useAsyncEffect, useMonkState } from '@monkvision/common';
+import { ComplianceIssue, Image, ImageStatus, Sight, TaskName } from '@monkvision/types';
 import { useMonitoring } from '@monkvision/monitoring';
 import { sights } from '@monkvision/sights';
 import { useMonkApi } from '@monkvision/network';
@@ -37,20 +37,40 @@ function createParams(): PhotoCaptureSightsParams {
   };
 }
 
-function mockGetInspectionResponse(inspectionId: string, takenSights: Sight[], tasks?: TaskName[]) {
-  return {
+function mockGetInspectionResponse(
+  inspectionId: string,
+  takenSights: Sight[],
+  tasks?: TaskName[],
+  nonCompliantSightIndex?: number,
+) {
+  const apiResponse = {
     entities: {
-      images: takenSights.map((sight, index) => ({
-        inspectionId,
-        additionalData: { sight_id: sight.id },
-        path: `test-path-${index}`,
-        mimetype: `test-mimetype-${index}`,
-        width: index * 2000,
-        height: index * 1000,
-      })),
+      images: [] as Image[],
       tasks: tasks?.map((name) => ({ inspectionId, name })),
     },
   };
+  takenSights.forEach((sight, index) => {
+    apiResponse.entities.images.push({
+      inspectionId,
+      additionalData: { sight_id: sight.id, created_at: '2020-01-01T01:01:01.001Z' },
+      path: `test-path-${index}`,
+      mimetype: `test-mimetype-${index}`,
+      width: index * 2000,
+      height: index * 1000,
+      status: nonCompliantSightIndex === index ? ImageStatus.NOT_COMPLIANT : ImageStatus.SUCCESS,
+    } as Image);
+    apiResponse.entities.images.push({
+      inspectionId,
+      additionalData: { sight_id: sight.id, created_at: '1998-01-01T01:01:01.001Z' },
+      path: `test-path-old-${index}`,
+      mimetype: `test-mimetype-old-${index}`,
+      width: index * 4000,
+      height: index * 2000,
+      status: ImageStatus.NOT_COMPLIANT,
+    } as Image);
+  });
+  (useMonkState as jest.Mock).mockImplementation(() => ({ state: apiResponse.entities }));
+  return apiResponse;
 }
 
 describe('usePhotoCaptureSightState hook', () => {
@@ -154,6 +174,60 @@ describe('usePhotoCaptureSightState hook', () => {
       height: images[images.length - 1].height,
     });
     expect(initialProps.loading.onSuccess).toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('should call onLastSightTaken if all sights have been taken after the getInspection API call', () => {
+    const initialProps = createParams();
+    const takenSights = initialProps.captureSights;
+    const apiResponse = mockGetInspectionResponse(initialProps.inspectionId, takenSights);
+    const { unmount } = renderHook(usePhotoCaptureSightState, { initialProps });
+
+    expect(useAsyncEffect).toHaveBeenCalled();
+    const { onResolve } = (useAsyncEffect as jest.Mock).mock.calls[0][2];
+    act(() => onResolve(apiResponse));
+    expect(initialProps.onLastSightTaken).toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('should select the first non compliant sight if all sights are taken after the getInspection API call', () => {
+    const initialProps = createParams();
+    const takenSights = initialProps.captureSights;
+    const sightToRetake = 2;
+    const apiResponse = mockGetInspectionResponse(
+      initialProps.inspectionId,
+      takenSights,
+      undefined,
+      sightToRetake,
+    );
+    const { result, unmount } = renderHook(usePhotoCaptureSightState, { initialProps });
+
+    expect(useAsyncEffect).toHaveBeenCalled();
+    const { onResolve } = (useAsyncEffect as jest.Mock).mock.calls[0][2];
+    act(() => onResolve(apiResponse));
+    expect(result.current.selectedSight).toEqual(initialProps.captureSights[sightToRetake]);
+    expect(result.current.sightsTaken).not.toContain(initialProps.captureSights[sightToRetake]);
+
+    unmount();
+  });
+
+  it('should select the last sight if all sights are taken and compliant after the getInspection API call', () => {
+    const initialProps = createParams();
+    const takenSights = initialProps.captureSights;
+    const apiResponse = mockGetInspectionResponse(initialProps.inspectionId, takenSights);
+    const { result, unmount } = renderHook(usePhotoCaptureSightState, { initialProps });
+
+    expect(useAsyncEffect).toHaveBeenCalled();
+    const { onResolve } = (useAsyncEffect as jest.Mock).mock.calls[0][2];
+    act(() => onResolve(apiResponse));
+    expect(result.current.selectedSight).toEqual(
+      initialProps.captureSights[initialProps.captureSights.length - 1],
+    );
+    expect(result.current.sightsTaken).not.toContain(
+      initialProps.captureSights[initialProps.captureSights.length - 1],
+    );
 
     unmount();
   });

--- a/packages/network/src/api/image/mappers.ts
+++ b/packages/network/src/api/image/mappers.ts
@@ -78,16 +78,17 @@ export function mapApiImage(
   inspectionId: string,
   complianceOptions?: ComplianceOptions,
 ): Image {
-  const { status, complianceIssues } = mapCompliance(
-    image.additional_data?.sight_id,
-    image.compliances,
-    complianceOptions,
-  );
+  const sightId = image.additional_data?.sight_id;
+  const { status, complianceIssues } = mapCompliance(sightId, image.compliances, complianceOptions);
   return {
     id: image.id,
     entityType: MonkEntityType.IMAGE,
     inspectionId,
     label: image.additional_data?.label,
+    sightId,
+    createdAt: image.additional_data?.created_at
+      ? Date.parse(image.additional_data.created_at)
+      : undefined,
     path: image.path,
     width: image.image_width,
     height: image.image_height,

--- a/packages/network/src/api/image/requests.ts
+++ b/packages/network/src/api/image/requests.ts
@@ -2,9 +2,9 @@ import ky from 'ky';
 import { Dispatch } from 'react';
 import { getFileExtensions, MonkActionType, MonkCreatedOneImageAction } from '@monkvision/common';
 import {
-  AdditionalData,
   ComplianceOptions,
   Image,
+  ImageAdditionalData,
   ImageStatus,
   ImageSubtype,
   ImageType,
@@ -100,13 +100,13 @@ function getImageLabel(options: AddImageOptions): TranslationObject | undefined 
   };
 }
 
-function getAdditionalData(options: AddImageOptions): AdditionalData {
-  const additionalData: AdditionalData = {
+function getAdditionalData(options: AddImageOptions): ImageAdditionalData {
+  const additionalData: ImageAdditionalData = {
     label: getImageLabel(options),
-    created_at: new Date(),
+    created_at: new Date().toISOString(),
   };
   if (options.type === ImageType.BEAUTY_SHOT) {
-    additionalData['sight_id'] = options.sightId;
+    additionalData.sight_id = options.sightId;
   }
   return additionalData;
 }
@@ -201,6 +201,7 @@ async function createImageFormData(
 }
 
 function createLocalImage(options: AddImageOptions): Image {
+  const additionalData = getAdditionalData(options);
   const image: Image = {
     entityType: MonkEntityType.IMAGE,
     id: v4(),
@@ -213,7 +214,9 @@ function createLocalImage(options: AddImageOptions): Image {
     type: options.type,
     status: ImageStatus.UPLOADING,
     label: getImageLabel(options),
-    additionalData: getAdditionalData(options),
+    additionalData,
+    sightId: additionalData.sight_id,
+    createdAt: additionalData.created_at ? Date.parse(additionalData.created_at) : undefined,
     views: [],
     renderedOutputs: [],
   };

--- a/packages/network/src/api/models/image.ts
+++ b/packages/network/src/api/models/image.ts
@@ -25,6 +25,7 @@ export interface ApiViewpointComponent {
 }
 
 export interface ApiImageAdditionalData extends ApiAdditionalData {
+  created_at?: string;
   sight_id?: string;
   label?: TranslationObject;
 }

--- a/packages/network/test/api/image/mappers.test.ts
+++ b/packages/network/test/api/image/mappers.test.ts
@@ -55,6 +55,7 @@ function createApiImage(params?: { sightId?: string }): ApiImage {
   return {
     additional_data: {
       sight_id: params?.sightId,
+      created_at: '2032-04-10T11:33:03.987Z',
       label: {
         en: 'test-label-en',
         fr: 'test-label-fr',
@@ -96,6 +97,8 @@ describe('Image API Mappers', () => {
       const apiImage = createApiImage({ sightId });
       expect(mapApiImage(apiImage, inspectionId)).toEqual({
         id: apiImage.id,
+        sightId: apiImage.additional_data?.sight_id,
+        createdAt: Date.parse(apiImage.additional_data?.created_at ?? ''),
         entityType: MonkEntityType.IMAGE,
         inspectionId,
         label: apiImage.additional_data?.label,

--- a/packages/network/test/api/inspection/data/apiInspectionGet.data.json
+++ b/packages/network/test/api/inspection/data/apiInspectionGet.data.json
@@ -101,6 +101,7 @@
       "additional_data": {
         "category": "exterior",
         "sight_id": "ffocus18-S3kgFOBb",
+        "created_at": "2024-05-07T14:28:45.965Z",
         "label": {
           "de": "Hinten Seitlich Niedrig Links",
           "en": "Rear Lateral Low Left",
@@ -2126,6 +2127,7 @@
       "additional_data": {
         "category": "exterior",
         "sight_id": "ffocus18-3TiCVAaN",
+        "created_at": "2024-05-07T14:28:45.965Z",
         "label": {
           "de": "Motorhaube",
           "en": "Hood",
@@ -3301,6 +3303,7 @@
     {
       "additional_data": {
         "category": "exterior",
+        "created_at": "2024-05-07T14:28:45.965Z",
         "label": {
           "de": "Dach",
           "en": "Roof",

--- a/packages/network/test/api/inspection/data/apiInspectionGet.data.ts
+++ b/packages/network/test/api/inspection/data/apiInspectionGet.data.ts
@@ -91,9 +91,12 @@ export default {
       ],
       complianceIssues: undefined,
       detailedViewpoint: undefined,
+      sightId: 'ffocus18-S3kgFOBb',
+      createdAt: 1715092125965,
       additionalData: {
         category: 'exterior',
         sight_id: 'ffocus18-S3kgFOBb',
+        created_at: '2024-05-07T14:28:45.965Z',
         label: {
           de: 'Hinten Seitlich Niedrig Links',
           en: 'Rear Lateral Low Left',
@@ -142,9 +145,12 @@ export default {
       ],
       complianceIssues: undefined,
       detailedViewpoint: undefined,
+      sightId: 'ffocus18-3TiCVAaN',
+      createdAt: 1715092125965,
       additionalData: {
         category: 'exterior',
         sight_id: 'ffocus18-3TiCVAaN',
+        created_at: '2024-05-07T14:28:45.965Z',
         label: {
           de: 'Motorhaube',
           en: 'Hood',
@@ -182,8 +188,10 @@ export default {
       viewpoint: undefined,
       complianceIssues: undefined,
       views: [],
+      createdAt: 1715092125965,
       additionalData: {
         category: 'exterior',
+        created_at: '2024-05-07T14:28:45.965Z',
         label: {
           de: 'Dach',
           en: 'Roof',

--- a/packages/types/src/state/image.ts
+++ b/packages/types/src/state/image.ts
@@ -351,6 +351,19 @@ export interface Image extends MonkEntity {
    */
   status: ImageStatus;
   /**
+   * The ID of the sight of the image. This value can be `undefined` for many reasons:
+   * - The picture was not taken by the MonkJs SDK or by an old version of the SDK
+   * - The picture does not have a corresponding sight (close-up etc.)
+   * - ...
+   */
+  sightId?: string;
+  /**
+   * The timestamp at which the image was created. This value can be `undefined` for many reasons (the picture was not
+   * taken by the MonkJs SDK or by an old version of the SDK etc.). This timestamp is generated using the `Date.now()`
+   * and` Date.parse()` APIs.
+   */
+  createdAt?: number;
+  /**
    * If the image status is equal to `ImageStatus.NOT_COMPLIANT` meaning that the compliance was enabled for this image
    * and the image was not compliant, the list of issues indicating why the image is not compliant is given in this
    * field. If the compliance was not enabled for this image or if the image is compliant, this property is not defined.


### PR DESCRIPTION
## Overview
<!-- Replace XXX with the ticket number in both the text and the link below -->
<!-- Or remove the line if there are no corresponding ticket -->
Jira Ticket Reference : [MN-524](https://acvauctions.atlassian.net/browse/MN-524)

- Fix compliance statuses not updating on refresh in SightSlider and ComplianceBadge
- Allow retake of compliant sights
- Fix refresh when every picture has been taken
- Added `sightId` and `createdAt` properties in `Image` interface to avoid having to deal with additional data everywhere

## Checklist before requesting a review
<!-- Make sure that all the items below are checked before requesting a review -->

- [x] I have updated the unit tests based on the changes I made
- [x] I have updated the docs (TSDoc / README / global doc) to reflect my changes
- [x] I have performed self-QA of my feature by testing the apps and packages and made sure that :
  - No regression or new bug has occurred
  - The acceptance criteria listed in the ticket are met
  - **Self-QA was made on both desktop and mobile**


[MN-524]: https://acvauctions.atlassian.net/browse/MN-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ