### PR TITLE
Handle the case where not all sights are in tasksBySight in useStartT…

### DIFF
--- a/packages/inspection-capture-web/src/PhotoCapture/hooks/useStartTasksOnComplete.ts
+++ b/packages/inspection-capture-web/src/PhotoCapture/hooks/useStartTasksOnComplete.ts
@@ -54,13 +54,11 @@ function getTasksToStart({
   UseStartTasksOnCompleteParams,
   'sights' | 'tasksBySight' | 'startTasksOnComplete'
 >): TaskName[] {
-  let tasks = [];
+  let tasks: TaskName[];
   if (Array.isArray(startTasksOnComplete)) {
     tasks = startTasksOnComplete;
-  } else if (tasksBySight) {
-    tasks = uniq(flatMap(sights, (sight) => tasksBySight[sight.id]));
   } else {
-    tasks = uniq(flatMap(sights, (sight) => sight.tasks));
+    tasks = uniq(flatMap(sights, (sight) => tasksBySight?.[sight.id] ?? sight.tasks));
   }
   return tasks.filter((task) => !TASKS_NOT_TO_START.includes(task));
 }


### PR DESCRIPTION
…asksOnComplete

## Overview
<!-- Replace XXX with the ticket number in both the text and the link below -->
<!-- Or remove the line if there are no corresponding ticket -->
Jira Ticket Reference : [MN-535](https://acvauctions.atlassian.net/browse/MN-535)

- Fixed an issue causing the Wheel Analysis task to not be patched to TODO in the Drive app

(The issue was caused by the fact that the useStartTasksOnComplete hook was assuming that the tasksBySight object contained a mapping for ALL sights, where in reality some sights could be missing.)

## Checklist before requesting a review
<!-- Make sure that all the items below are checked before requesting a review -->

- [x] I have updated the unit tests based on the changes I made
- [x] I have updated the docs (TSDoc / README / global doc) to reflect my changes
- [x] I have performed self-QA of my feature by testing the apps and packages and made sure that :
  - No regression or new bug has occurred
  - The acceptance criteria listed in the ticket are met
  - **Self-QA was made on both desktop and mobile**


[MN-535]: https://acvauctions.atlassian.net/browse/MN-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ