### PR TITLE
Fixed the aspect ratio of the sights

### DIFF
--- a/apps/demo-app/.env-cmdrc.json
+++ b/apps/demo-app/.env-cmdrc.json
@@ -37,5 +37,14 @@
     "REACT_APP_AUTH_CLIENT_ID": "O7geYcPM6zEJrHw0WvQVzSIzw4WzrAtH",
     "REACT_APP_SENTRY_DSN": "https://74f50bfe6f11de7aefd54acfa5dfed96@o4505669501648896.ingest.us.sentry.io/4506863461662720",
     "REACT_APP_INSPECTION_REPORT_URL": "https://demo-capture.preview.monk.ai"
+  },
+  "backend-staging-qa": {
+    "REACT_APP_ENVIRONMENT": "backend-staging-qa",
+    "REACT_APP_API_DOMAIN": "api.staging.monk.ai/v1",
+    "REACT_APP_AUTH_DOMAIN": "idp.staging.monk.ai",
+    "REACT_APP_AUTH_AUDIENCE": "https://api.monk.ai/v1/",
+    "REACT_APP_AUTH_CLIENT_ID": "DAeZWqeeOfgItYBcQzFeFwSrlvmUdN7L",
+    "REACT_APP_SENTRY_DSN": "https://74f50bfe6f11de7aefd54acfa5dfed96@o4505669501648896.ingest.us.sentry.io/4506863461662720",
+    "REACT_APP_INSPECTION_REPORT_URL": "https://demo-capture.staging.monk.ai"
   }
 }

--- a/apps/demo-app/package.json
+++ b/apps/demo-app/package.json
@@ -11,6 +11,7 @@
     "build:development": "env-cmd -e development react-scripts build",
     "build:staging": "env-cmd -e staging react-scripts build",
     "build:preview": "env-cmd -e preview react-scripts build",
+    "build:backend-staging-qa": "env-cmd -e backend-staging-qa react-scripts build",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "analyze": "source-map-explorer 'build/static/js/*.js'",

--- a/apps/drive-app/.env-cmdrc.json
+++ b/apps/drive-app/.env-cmdrc.json
@@ -36,5 +36,13 @@
     "REACT_APP_AUTH_AUDIENCE": "https://api.monk.ai/v1/",
     "REACT_APP_AUTH_CLIENT_ID": "O7geYcPM6zEJrHw0WvQVzSIzw4WzrAtH",
     "REACT_APP_SENTRY_DSN": "https://496e3a7f8e04df38e76d579c27c30e87@o4505669501648896.ingest.us.sentry.io/4507169054326784"
+  },
+  "backend-staging-qa": {
+    "REACT_APP_ENVIRONMENT": "backend-staging-qa",
+    "REACT_APP_API_DOMAIN": "api.staging.monk.ai/v1",
+    "REACT_APP_AUTH_DOMAIN": "idp.staging.monk.ai",
+    "REACT_APP_AUTH_AUDIENCE": "https://api.monk.ai/v1/",
+    "REACT_APP_AUTH_CLIENT_ID": "DAeZWqeeOfgItYBcQzFeFwSrlvmUdN7L",
+    "REACT_APP_SENTRY_DSN": "https://496e3a7f8e04df38e76d579c27c30e87@o4505669501648896.ingest.us.sentry.io/4507169054326784"
   }
 }

--- a/apps/drive-app/package.json
+++ b/apps/drive-app/package.json
@@ -11,6 +11,7 @@
     "build:development": "env-cmd -e development react-scripts build",
     "build:staging": "env-cmd -e staging react-scripts build",
     "build:preview": "env-cmd -e preview react-scripts build",
+    "build:backend-staging-qa": "env-cmd -e backend-staging-qa react-scripts build",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "analyze": "source-map-explorer 'build/static/js/*.js'",

--- a/packages/camera-web/README.md
+++ b/packages/camera-web/README.md
@@ -171,10 +171,11 @@ Main component exported by this package, displays a Camera preview and the given
 Object passed to Camera HUD components that is used to control the camera
 
 ### Properties
-| Prop        | Type                       | Description                                                                   |
-|-------------|----------------------------|-------------------------------------------------------------------------------|
-| takePicture | () => MonkPicture          | A function that you can call to ask the camera to take a picture.             |
-| error       | UserMediaError &#124; null | The error details if there has been an error when fetching the camera stream. |
-| isLoading   | boolean                    | Boolean indicating if the camera preview is loading.                          |
-| retry       | () => void                 | A function to retry the camera stream fetching in case of error.              |
-| dimensions  | PixelDimensions            | The Camera stream dimensions (`null` if there is no stream).                  |
+| Prop              | Type                        | Description                                                                                              |
+|-------------------|-----------------------------|----------------------------------------------------------------------------------------------------------|
+| takePicture       | () => MonkPicture           | A function that you can call to ask the camera to take a picture.                                        |
+| error             | UserMediaError &#124; null  | The error details if there has been an error when fetching the camera stream.                            |
+| isLoading         | boolean                     | Boolean indicating if the camera preview is loading.                                                     |
+| retry             | () => void                  | A function to retry the camera stream fetching in case of error.                                         |
+| dimensions        | PixelDimensions &#124; null | The Camera stream dimensions (`null` if there is no stream).                                             |
+| previewDimensions | PixelDimensions &#124; null | The effective video dimensions of the Camera stream on the client screen (`null` if there is no stream). |

--- a/packages/camera-web/src/Camera/Camera.tsx
+++ b/packages/camera-web/src/Camera/Camera.tsx
@@ -103,6 +103,7 @@ export function Camera<T extends object>({
   const {
     ref: videoRef,
     dimensions: streamDimensions,
+    previewDimensions,
     error,
     retry,
     isLoading: isPreviewLoading,
@@ -148,7 +149,14 @@ export function Camera<T extends object>({
 
   return HUDComponent ? (
     <HUDComponent
-      handle={{ takePicture, error, retry, isLoading, dimensions: streamDimensions }}
+      handle={{
+        takePicture,
+        error,
+        retry,
+        isLoading,
+        dimensions: streamDimensions,
+        previewDimensions,
+      }}
       cameraPreview={cameraPreview}
       {...((hudProps ?? {}) as T)}
     />

--- a/packages/camera-web/src/Camera/CameraHUD.types.ts
+++ b/packages/camera-web/src/Camera/CameraHUD.types.ts
@@ -27,6 +27,10 @@ export interface CameraHandle {
    * stream constraints if they are not supported or available on the current device.
    */
   dimensions: PixelDimensions | null;
+  /**
+   * The effective pixel dimensions of the video stream on the client screen.
+   */
+  previewDimensions: PixelDimensions | null;
 }
 
 /**

--- a/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUD.tsx
+++ b/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUD.tsx
@@ -146,7 +146,7 @@ export function PhotoCaptureHUD({
           onRetakeSight={onRetakeSight}
           isLoading={loading.isLoading || handle.isLoading}
           error={loading.error ?? handle.error}
-          streamDimensions={handle.dimensions}
+          previewDimensions={handle.previewDimensions}
           images={images}
           enableAddDamage={enableAddDamage}
         />

--- a/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDElements/PhotoCaptureHUDElements.tsx
+++ b/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDElements/PhotoCaptureHUDElements.tsx
@@ -41,9 +41,9 @@ export interface PhotoCaptureHUDElementsProps {
    */
   onRetakeSight: (sight: string) => void;
   /**
-   * The dimensions of the Camera video stream.
+   * The effective pixel dimensions of the Camera video stream on the screen.
    */
-  streamDimensions: PixelDimensions | null;
+  previewDimensions: PixelDimensions | null;
   /**
    * Boolean indicating if the global loading state of the PhotoCapture component is loading or not.
    */
@@ -80,7 +80,7 @@ export function PhotoCaptureHUDElements(params: PhotoCaptureHUDElementsProps) {
         onRetakeSight={params.onRetakeSight}
         sightsTaken={params.sightsTaken}
         onAddDamage={params.onAddDamage}
-        streamDimensions={params.streamDimensions}
+        previewDimensions={params.previewDimensions}
         images={params.images}
         enableAddDamage={params.enableAddDamage}
       />
@@ -92,7 +92,7 @@ export function PhotoCaptureHUDElements(params: PhotoCaptureHUDElementsProps) {
   return (
     <PhotoCaptureHUDElementsAddDamage2ndShot
       onCancel={params.onCancelAddDamage}
-      streamDimensions={params.streamDimensions}
+      streamDimensions={params.previewDimensions}
     />
   );
 }

--- a/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDElementsSight/PhotoCaptureHUDElementsSight.tsx
+++ b/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDElementsSight/PhotoCaptureHUDElementsSight.tsx
@@ -17,15 +17,15 @@ export function PhotoCaptureHUDElementsSight({
   onRetakeSight = () => {},
   onAddDamage = () => {},
   sightsTaken,
-  streamDimensions,
+  previewDimensions,
   images,
   enableAddDamage,
 }: PhotoCaptureHUDElementsSightProps) {
-  const style = usePhotoCaptureHUDSightPreviewStyle({ streamDimensions });
+  const style = usePhotoCaptureHUDSightPreviewStyle({ previewDimensions });
 
   return (
     <div style={styles['container']}>
-      {streamDimensions && <SightOverlay style={style.overlay} sight={selectedSight} />}
+      {previewDimensions && <SightOverlay style={style.overlay} sight={selectedSight} />}
       <div style={style.elementsContainer}>
         <div style={style.top}>
           <AddDamageButton onAddDamage={onAddDamage} enableAddDamage={enableAddDamage} />

--- a/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDElementsSight/hooks.ts
+++ b/packages/inspection-capture-web/src/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDElementsSight/hooks.ts
@@ -31,9 +31,9 @@ export interface PhotoCaptureHUDElementsSightProps {
    */
   sightsTaken: Sight[];
   /**
-   * The dimensions of the Camera video stream.
+   * The effective pixel dimensions of the Camera video stream on the screen.
    */
-  streamDimensions?: PixelDimensions | null;
+  previewDimensions?: PixelDimensions | null;
   /**
    * The current images taken by the user (ignoring retaken pictures etc.).
    */
@@ -47,10 +47,9 @@ export interface PhotoCaptureHUDElementsSightProps {
 }
 
 export function usePhotoCaptureHUDSightPreviewStyle({
-  streamDimensions,
-}: Pick<PhotoCaptureHUDElementsSightProps, 'streamDimensions'>) {
+  previewDimensions,
+}: Pick<PhotoCaptureHUDElementsSightProps, 'previewDimensions'>) {
   const { responsive } = useResponsiveStyle();
-  const aspectRatio = `${streamDimensions?.width}/${streamDimensions?.height}`;
 
   return {
     container: styles['container'],
@@ -62,7 +61,8 @@ export function usePhotoCaptureHUDSightPreviewStyle({
     bottom: styles['bottom'],
     overlay: {
       ...styles['overlay'],
-      aspectRatio,
+      width: previewDimensions?.width,
+      height: previewDimensions?.height,
     },
   };
 }

--- a/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUD.test.tsx
+++ b/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUD.test.tsx
@@ -58,6 +58,7 @@ function createProps(): PhotoCaptureHUDProps {
       isLoading: false,
       error: null,
       dimensions: { height: 2, width: 4 },
+      previewDimensions: { height: 111, width: 2222 },
     } as unknown as CameraHandle,
     cameraPreview: <div data-testid={cameraTestId}></div>,
     images: [{ sightId: 'test-sight-1', status: ImageStatus.NOT_COMPLIANT }] as Image[],
@@ -92,7 +93,7 @@ describe('PhotoCaptureHUD component', () => {
       onSelectSight: props.onSelectSight,
       isLoading: props.loading.isLoading || props.handle.isLoading,
       error: props.loading.error ?? props.handle.error,
-      streamDimensions: props.handle.dimensions,
+      previewDimensions: props.handle.previewDimensions,
       images: props.images,
     });
 

--- a/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDElements.test.tsx
+++ b/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDElements.test.tsx
@@ -40,7 +40,7 @@ function createProps(): PhotoCaptureHUDElementsProps {
     onCancelAddDamage: jest.fn(),
     onSelectSight: jest.fn(),
     onRetakeSight: jest.fn(),
-    streamDimensions: { height: 1234, width: 45678 },
+    previewDimensions: { height: 1234, width: 45678 },
     isLoading: false,
     error: null,
     images: [{ sightId: 'test-sight-1', status: ImageStatus.NOT_COMPLIANT }] as Image[],
@@ -83,7 +83,7 @@ describe('PhotoCaptureHUDElements component', () => {
       onSelectedSight: props.onSelectSight,
       sightsTaken: props.sightsTaken,
       onAddDamage: props.onAddDamage,
-      streamDimensions: props.streamDimensions,
+      previewDimensions: props.previewDimensions,
       images: props.images,
     });
     expect(PhotoCaptureHUDElementsAddDamage1stShot).not.toHaveBeenCalled();

--- a/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDElementsSight/PhotoCaptureHUDElementsSight.test.tsx
+++ b/packages/inspection-capture-web/test/PhotoCapture/PhotoCaptureHUD/PhotoCaptureHUDElementsSight/PhotoCaptureHUDElementsSight.test.tsx
@@ -42,7 +42,7 @@ function createProps(): PhotoCaptureHUDElementsSightProps {
     sightsTaken: [captureSights[0], captureSights[1]],
     onSelectedSight: jest.fn(),
     onAddDamage: jest.fn(),
-    streamDimensions: { width: 4563, height: 992 },
+    previewDimensions: { width: 4563, height: 992 },
     images: [
       { sightId: 'test-sight-1', status: ImageStatus.NOT_COMPLIANT },
       { sightId: 'test-sight-2', status: ImageStatus.SUCCESS },
@@ -51,14 +51,15 @@ function createProps(): PhotoCaptureHUDElementsSightProps {
 }
 
 describe('PhotoCaptureHUDElementsSight component', () => {
-  it('should display the current sight overlay with the proper aspect ratio', () => {
+  it('should display the current sight overlay with the proper dimensions', () => {
     const props = createProps();
     const { unmount } = render(<PhotoCaptureHUDElementsSight {...props} />);
 
     expectPropsOnChildMock(SightOverlay, {
       sight: props.selectedSight,
       style: expect.objectContaining({
-        aspectRatio: `${props.streamDimensions?.width}/${props.streamDimensions?.height}`,
+        width: props.previewDimensions?.width,
+        height: props.previewDimensions?.height,
       }),
     });
 


### PR DESCRIPTION
## Overview
<!-- Replace XXX with the ticket number in both the text and the link below -->
<!-- Or remove the line if there are no corresponding ticket -->
Jira Ticket Reference : [MN-522](https://acvauctions.atlassian.net/browse/MN-522)

This PR fixes an issue causing the sight overlays to sometimes go out of the camera stream bounds. This issue was caused by the fact that the `aspectRatio` property (used to properly size the sight overlay compared to the camera stream) is bugged in Safari and doesn't work as expected. To fix this, I added a function that automatically calculates the effective size of the camera preview on the stream in pixels, added these dimensions to the camera handle, and used them in the PhotoCapture component to properly size the sight overlay without having to use `aspectRatio`.

## Checklist before requesting a review
<!-- Make sure that all the items below are checked before requesting a review -->

- [x] I have updated the unit tests based on the changes I made
- [x] I have updated the docs (TSDoc / README / global doc) to reflect my changes
- [x] I have performed self-QA of my feature by testing the apps and packages and made sure that :
  - No regression or new bug has occurred
  - The acceptance criteria listed in the ticket are met
  - **Self-QA was made on both desktop and mobile**


[MN-522]: https://acvauctions.atlassian.net/browse/MN-522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ