### PR TITLE
docs: correct a spelling mistake

### DIFF
--- a/documentation/docs/monitoring.md
+++ b/documentation/docs/monitoring.md
@@ -70,7 +70,7 @@ import { EmptyMonitoringAdapter } from '@monkvision/monitoring';
 
 const adapter = new EmptyMonitoringAdapter();
 ```
-This Monitoring Adapter does nothing. It is basically an ampty adapter with empty callbacks for every monitoring
+This Monitoring Adapter does nothing. It is basically an empty adapter with empty callbacks for every monitoring
 utility. It is the default monitoring adapter that is returned and used if you use the `useMonitoring` hook in a
 component that is not a child of a `MonitoringProvider` component.
 


### PR DESCRIPTION
## Overview
While reading the document from the website, I found a word misspelled. I changed the wrong word to "empty".
<img width="1512" height="861" alt="Screenshot 2025-07-23 at 7 46 15 pm" src="https://github.com/user-attachments/assets/cc94555b-513a-42d6-b5c8-b6dde3541386" />


<!-- Provide a small description of this PR and the feature it implements -->

## Checklist before requesting a review
<!-- Make sure that all the items below are checked before requesting a review -->

- [N] I have updated the unit tests based on the changes I made
- [N] I have updated the docs (TSDoc / README / global doc) to reflect my changes
- [N] I have updated the local app configs if needed
- [N] I have performed self-QA of my feature by testing the apps and packages and made sure that :
  - No regression or new bug has occurred
  - The acceptance criteria listed in the ticket are met
  - **Self-QA was made on both desktop and mobile**
