### PR TITLE
Separated the logic between uploadedFrames and totalUploadingFrames

### DIFF
--- a/packages/inspection-capture-web/src/VideoCapture/hooks/useVideoUploadQueue.ts
+++ b/packages/inspection-capture-web/src/VideoCapture/hooks/useVideoUploadQueue.ts
@@ -4,7 +4,7 @@ import { getInspectionImages, useMonkState, useObjectMemo, useQueue } from '@mon
 import { DeviceRotation, MonkPicture } from '@monkvision/types';
 import { ImageUploadType, MonkApiConfig, useMonkApi } from '@monkvision/network';
 import { useMonitoring } from '@monkvision/monitoring';
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 interface VideoFrameUpload {
   picture: MonkPicture;
@@ -71,6 +71,8 @@ export function useVideoUploadQueue({
   const { addImage, deleteImagesBulk } = useMonkApi(apiConfig);
   const { state } = useMonkState();
   const { handleError } = useMonitoring();
+  const [uploadedFrames, setUploadedFrames] = useState(0);
+  const [totalUploadingFrames, setTotalUploadingFrames] = useState(0);
 
   const queue = useQueue(
     (upload: VideoFrameUpload) =>
@@ -84,6 +86,9 @@ export function useVideoUploadQueue({
       }),
     {
       storeFailedItems: true,
+      onItemComplete: () => {
+        setUploadedFrames((count) => count + 1);
+      },
       onItemFail: (upload: VideoFrameUpload) => {
         upload.retryCount += 1;
         if (upload.retryCount <= maxRetryCount) {
@@ -106,6 +111,7 @@ export function useVideoUploadQueue({
       queue.push(upload);
       frameIndex.current += 1;
       frameTimestamp.current = now;
+      setTotalUploadingFrames((count) => count + 1);
     },
     [queue.push],
   );
@@ -121,8 +127,8 @@ export function useVideoUploadQueue({
   }, [deleteImagesBulk, inspectionId, state.images, handleError, queue]);
 
   return useObjectMemo({
-    uploadedFrames: queue.totalItems - queue.processingCount,
-    totalUploadingFrames: queue.totalItems,
+    uploadedFrames,
+    totalUploadingFrames,
     onFrameSelected,
     discardUploadedImages,
   });

--- a/packages/inspection-capture-web/test/VideoCapture/hooks/useVideoUploadQueue.test.ts
+++ b/packages/inspection-capture-web/test/VideoCapture/hooks/useVideoUploadQueue.test.ts
@@ -27,10 +27,10 @@ describe('useVideoUploadQueue hook', () => {
 
   it('should push items to the queue with the proper params', () => {
     const initialProps = createProps();
-    const { result, rerender, unmount } = renderHook(() => useVideoUploadQueue(initialProps));
+    const { result, unmount } = renderHook(() => useVideoUploadQueue(initialProps));
 
     expect(useQueue).toHaveBeenCalled();
-    let { push } = (useQueue as jest.Mock).mock.results[0].value;
+    let push = (useQueue as jest.Mock).mock.results.at(-1)?.value.push;
 
     expect(push).not.toHaveBeenCalled();
     const picture1 = { uri: 'test-uri-1' } as unknown as MonkPicture;
@@ -48,8 +48,7 @@ describe('useVideoUploadQueue hook', () => {
 
     const time = 5491;
     jest.advanceTimersByTime(time);
-    rerender();
-    push = (useQueue as jest.Mock).mock.results[1].value.push;
+    push = (useQueue as jest.Mock).mock.results.at(-1)?.value.push;
 
     expect(push).not.toHaveBeenCalled();
     const picture2 = { uri: 'test-uri-2' } as unknown as MonkPicture;
@@ -139,20 +138,42 @@ describe('useVideoUploadQueue hook', () => {
     unmount();
   });
 
-  it('should return the uploaded frames and the total uploading frames', () => {
-    const totalItems = 2345;
-    const processingCount = 123;
-    (useQueue as jest.Mock).mockImplementationOnce(() => ({
-      push: jest.fn(),
-      clear: jest.fn(),
-      totalItems,
-      processingCount,
-    }));
+  it('should count uploaded frames only once per distinct frame, regardless of retries', () => {
     const initialProps = createProps();
     const { result, unmount } = renderHook(() => useVideoUploadQueue(initialProps));
 
-    expect(result.current.uploadedFrames).toEqual(totalItems - processingCount);
-    expect(result.current.totalUploadingFrames).toEqual(totalItems);
+    expect(result.current.uploadedFrames).toEqual(0);
+    expect(result.current.totalUploadingFrames).toEqual(0);
+
+    const picture1 = { uri: 'test-uri-1' } as unknown as MonkPicture;
+    const picture2 = { uri: 'test-uri-2' } as unknown as MonkPicture;
+    act(() => {
+      result.current.onFrameSelected(picture1);
+      result.current.onFrameSelected(picture2);
+    });
+
+    expect(result.current.totalUploadingFrames).toEqual(2);
+    expect(result.current.uploadedFrames).toEqual(0);
+
+    const { onItemComplete, onItemFail } = (useQueue as jest.Mock).mock.calls[0][1];
+    const upload = {
+      picture: picture1,
+      frameIndex: 0,
+      timestamp: 0,
+      retryCount: 0,
+    };
+
+    act(() => {
+      onItemFail(upload);
+    });
+    expect(result.current.uploadedFrames).toEqual(0);
+    expect(result.current.totalUploadingFrames).toEqual(2);
+
+    act(() => {
+      onItemComplete(upload);
+    });
+    expect(result.current.uploadedFrames).toEqual(1);
+    expect(result.current.totalUploadingFrames).toEqual(2);
 
     unmount();
   });


### PR DESCRIPTION
## Overview
<!-- Replace XXX with the ticket number in both the text and the link below -->
<!-- Or remove the line if there are no corresponding ticket -->
Jira Ticket Reference : [MN-890](https://acvauctions.atlassian.net/browse/MN-890)

<!-- Provide a small description of this PR and the feature it implements -->
Right now, we are counting the retries of an uploaded frame, increasing the counter of total uploaded frames, which is incorrect.
There should be a clear split between uploadedFrames and totalUploadingFrames.

## Checklist before requesting a review
<!-- Make sure that all the items below are checked before requesting a review -->

- [x] I have updated the unit tests based on the changes I made
- [x] I have updated the docs (TSDoc / README / global doc) to reflect my changes
- [x] I have updated the local app configs if needed
- [x] I have performed self-QA of my feature by testing the apps and packages and made sure that :
  - No regression or new bug has occurred
  - The acceptance criteria listed in the ticket are met
  - **Self-QA was made on both desktop and mobile**


[MN-890]: https://acvauctions.atlassian.net/browse/MN-890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ