### PR TITLE
Avoid race condition between Starting Tasks and Deleting Image

### DIFF
--- a/packages/inspection-capture-web/src/PhotoCapture/PhotoCapture.tsx
+++ b/packages/inspection-capture-web/src/PhotoCapture/PhotoCapture.tsx
@@ -244,7 +244,7 @@ export function PhotoCapture({
     closeBadConnectionWarningDialog,
     uploadEventHandlers: badConnectionWarningUploadEventHandlers,
   } = useBadConnectionWarning({ maxUploadDurationWarning });
-  const { cleanupEventHandlers } = useImagesCleanup({
+  const { cleanupEventHandlers, cleanupImages } = useImagesCleanup({
     inspectionId,
     apiConfig,
     autoDeletePreviousSightImages,
@@ -279,6 +279,7 @@ export function PhotoCapture({
     loading,
     startTasksOnComplete,
     onUpdateDuration: updateDuration,
+    cleanupImages,
     onComplete,
   });
   const handleGalleryBack = () => setCurrentScreen(PhotoCaptureScreen.CAMERA);

--- a/packages/inspection-capture-web/src/PhotoCapture/hooks/useImagesCleanup.ts
+++ b/packages/inspection-capture-web/src/PhotoCapture/hooks/useImagesCleanup.ts
@@ -1,6 +1,6 @@
 import { useMonkState, useObjectMemo } from '@monkvision/common';
-import { MonkApiConfig, useMonkApi } from '@monkvision/network';
-import { useCallback } from 'react';
+import { MonkApiConfig, MonkApiResponse, useMonkApi } from '@monkvision/network';
+import { useCallback, useRef } from 'react';
 import { Image, ImageStatus } from '@monkvision/types';
 import { UploadEventHandlers, UploadSuccessPayload } from '../../hooks/useUploadQueue';
 
@@ -38,6 +38,10 @@ export interface ImagesCleanupHandle {
    * A set of event handlers listening to upload events.
    */
   cleanupEventHandlers: UploadEventHandlers;
+  /**
+   * Function returning a promise that resolves when every pending image deletion request has settled.
+   */
+  cleanupImages: () => Promise<void>;
 }
 
 function extractOtherImagesToDelete(imagesBySight: Record<string, Image[]>): Image[] {
@@ -82,6 +86,23 @@ export function useImagesCleanup({
 }: ImagesCleanupParams): ImagesCleanupHandle {
   const { deleteImage } = useMonkApi(apiConfig);
   const { state } = useMonkState();
+  const pendingCleanup = useRef<Promise<unknown>>(Promise.resolve());
+  const pendingDeletionIds = useRef<Set<string>>(new Set());
+
+  const cleanupImages = useCallback(async function cleanup(
+    deletions: Promise<MonkApiResponse>[] = [],
+  ): Promise<void> {
+    if (deletions.length > 0) {
+      pendingCleanup.current = Promise.allSettled([pendingCleanup.current, ...deletions]);
+    }
+    const awaitedCleanup = pendingCleanup.current;
+    await awaitedCleanup;
+
+    if (awaitedCleanup !== pendingCleanup.current) {
+      await cleanup();
+    }
+  },
+  []);
 
   const onUploadSuccess = useCallback(
     ({ sightId, imageId }: UploadSuccessPayload) => {
@@ -101,18 +122,31 @@ export function useImagesCleanup({
           DELETABLE_STATUSES.includes(image.status),
       );
 
-      const imagesToDelete = [...otherImagesToDelete, ...sightImagesToDelete];
+      const imagesToDelete = [...otherImagesToDelete, ...sightImagesToDelete].filter(
+        (image) => !pendingDeletionIds.current.has(image.id),
+      );
 
       if (imagesToDelete.length > 0) {
-        imagesToDelete.forEach((image) => deleteImage({ imageId: image.id, id: inspectionId }));
+        cleanupImages(
+          imagesToDelete.map(async (image) => {
+            pendingDeletionIds.current.add(image.id);
+            try {
+              return await deleteImage({ imageId: image.id, id: inspectionId });
+            } catch (err) {
+              pendingDeletionIds.current.delete(image.id);
+              throw err;
+            }
+          }),
+        );
       }
     },
-    [state.images, inspectionId],
+    [state.images, inspectionId, cleanupImages],
   );
 
   return useObjectMemo({
     cleanupEventHandlers: {
       onUploadSuccess,
     },
+    cleanupImages,
   });
 }

--- a/packages/inspection-capture-web/src/PhotoCapture/hooks/useInspectionComplete.ts
+++ b/packages/inspection-capture-web/src/PhotoCapture/hooks/useInspectionComplete.ts
@@ -28,6 +28,10 @@ export interface InspectionCompleteParams
    */
   onUpdateDuration: (forceUpdate?: boolean) => Promise<number>;
   /**
+   * Function returning a promise that resolves when every pending image deletion request has settled.
+   */
+  cleanupImages: () => Promise<void>;
+  /**
    * Callback called when the user clicks on the "Complete" button in the HUD.
    */
   onComplete?: () => void;
@@ -52,6 +56,7 @@ export function useInspectionComplete({
   loading,
   startTasksOnComplete,
   onUpdateDuration,
+  cleanupImages,
   onComplete,
 }: InspectionCompleteParams): InspectionCompleteHandle {
   const analytics = useAnalytics();
@@ -59,6 +64,8 @@ export function useInspectionComplete({
 
   const handleInspectionCompleted = useCallback(async () => {
     const updatedDuration = await onUpdateDuration(true);
+    loading.start();
+    await cleanupImages();
     startTasks()
       .then(() => {
         analytics.trackEvent('Capture Completed', {
@@ -75,7 +82,7 @@ export function useInspectionComplete({
         loading.onError(err);
         monitoring.handleError(err);
       });
-  }, []);
+  }, [cleanupImages]);
 
   useEffect(() => {
     const { isInspectionCompliant, isInspectionCompleted } = sightState;

--- a/packages/inspection-capture-web/test/PhotoCapture/PhotoCapture.test.tsx
+++ b/packages/inspection-capture-web/test/PhotoCapture/PhotoCapture.test.tsx
@@ -349,6 +349,7 @@ describe('PhotoCapture component', () => {
       startTasks,
       sightState,
       onUpdateDuration: duration.updateDuration,
+      cleanupImages: expect.any(Function),
       loading,
       onComplete: props.onComplete,
     });

--- a/packages/inspection-capture-web/test/PhotoCapture/hooks/useImagesCleanup.test.ts
+++ b/packages/inspection-capture-web/test/PhotoCapture/hooks/useImagesCleanup.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 import { useMonkApi } from '@monkvision/network';
 import { useMonkState } from '@monkvision/common';
 import { ImageStatus } from '@monkvision/types';
+import { createFakePromise, FakePromise, flushPromises } from '@monkvision/test-utils';
 import { ImagesCleanupParams, useImagesCleanup } from '../../../src/PhotoCapture/hooks';
 
 const apiConfig = {
@@ -114,6 +115,126 @@ describe('useImagesCleanup hook', () => {
     });
 
     expect(deleteImage).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('should resolve the cleanupImages promise right away if there is no pending deletion', async () => {
+    const deleteImage = jest.fn(() => Promise.resolve());
+    (useMonkApi as jest.Mock).mockImplementation(() => ({ deleteImage }));
+    (useMonkState as jest.Mock).mockImplementation(() => ({ state }));
+
+    const { result, unmount } = renderHook(useImagesCleanup, {
+      initialProps: createInitialProps(),
+    });
+
+    await expect(result.current.cleanupImages()).resolves.toBeUndefined();
+    expect(deleteImage).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('should not resolve the cleanupImages promise until the pending deletions are settled', async () => {
+    const deletions: FakePromise<void>[] = [];
+    const deleteImage = jest.fn(() => {
+      const deletion = createFakePromise<void>();
+      deletions.push(deletion);
+      return deletion;
+    });
+    (useMonkApi as jest.Mock).mockImplementation(() => ({ deleteImage }));
+    (useMonkState as jest.Mock).mockImplementation(() => ({ state }));
+
+    const { result, unmount } = renderHook(useImagesCleanup, {
+      initialProps: createInitialProps(),
+    });
+
+    act(() => {
+      result.current.cleanupEventHandlers.onUploadSuccess?.({ sightId: 'sight-1' });
+    });
+    expect(deletions.length).toBe(4);
+
+    let isCleanupCompleted = false;
+    const cleanupPromise = result.current.cleanupImages().then(() => {
+      isCleanupCompleted = true;
+    });
+    await flushPromises();
+    expect(isCleanupCompleted).toBe(false);
+
+    deletions.forEach((deletion) => deletion.resolve());
+    await cleanupPromise;
+    expect(isCleanupCompleted).toBe(true);
+
+    unmount();
+  });
+
+  it('should not delete an image that already has a deletion request in flight', async () => {
+    const deletions: FakePromise<void>[] = [];
+    const deleteImage = jest.fn(() => {
+      const deletion = createFakePromise<void>();
+      deletions.push(deletion);
+      return deletion;
+    });
+    (useMonkApi as jest.Mock).mockImplementation(() => ({ deleteImage }));
+    (useMonkState as jest.Mock).mockImplementation(() => ({ state }));
+
+    const { result, unmount } = renderHook(useImagesCleanup, {
+      initialProps: createInitialProps(),
+    });
+
+    act(() => {
+      result.current.cleanupEventHandlers.onUploadSuccess?.({ sightId: 'sight-1' });
+    });
+    expect(deleteImage).toHaveBeenCalledTimes(4);
+
+    act(() => {
+      result.current.cleanupEventHandlers.onUploadSuccess?.({ sightId: 'sight-1' });
+    });
+    expect(deleteImage).toHaveBeenCalledTimes(4);
+
+    deletions.forEach((deletion) => deletion.resolve());
+    await expect(result.current.cleanupImages()).resolves.toBeUndefined();
+
+    unmount();
+  });
+
+  it('should delete an image again if its previous deletion request failed', async () => {
+    const deleteImage = jest.fn(() => Promise.reject(new Error('test-error-message')));
+    (useMonkApi as jest.Mock).mockImplementation(() => ({ deleteImage }));
+    (useMonkState as jest.Mock).mockImplementation(() => ({ state }));
+
+    const { result, unmount } = renderHook(useImagesCleanup, {
+      initialProps: createInitialProps(),
+    });
+
+    act(() => {
+      result.current.cleanupEventHandlers.onUploadSuccess?.({ sightId: 'sight-1' });
+    });
+    expect(deleteImage).toHaveBeenCalledTimes(4);
+    await flushPromises();
+
+    act(() => {
+      result.current.cleanupEventHandlers.onUploadSuccess?.({ sightId: 'sight-1' });
+    });
+    expect(deleteImage).toHaveBeenCalledTimes(8);
+
+    unmount();
+  });
+
+  it('should resolve the cleanupImages promise even if a deletion request fails', async () => {
+    const deleteImage = jest.fn(() => Promise.reject(new Error('test-error-message')));
+    (useMonkApi as jest.Mock).mockImplementation(() => ({ deleteImage }));
+    (useMonkState as jest.Mock).mockImplementation(() => ({ state }));
+
+    const { result, unmount } = renderHook(useImagesCleanup, {
+      initialProps: createInitialProps(),
+    });
+
+    act(() => {
+      result.current.cleanupEventHandlers.onUploadSuccess?.({ sightId: 'sight-1' });
+    });
+    expect(deleteImage).toHaveBeenCalled();
+
+    await expect(result.current.cleanupImages()).resolves.toBeUndefined();
 
     unmount();
   });

--- a/packages/inspection-capture-web/test/PhotoCapture/hooks/useInspectionComplete.test.ts
+++ b/packages/inspection-capture-web/test/PhotoCapture/hooks/useInspectionComplete.test.ts
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react';
+import { LoadingState } from '@monkvision/common';
+import { createFakePromise, FakePromise, flushPromises } from '@monkvision/test-utils';
+import {
+  InspectionCompleteParams,
+  PhotoCaptureSightState,
+  useInspectionComplete,
+} from '../../../src/PhotoCapture/hooks';
+
+function createParams(
+  imagesCleanupPromise: FakePromise<void>,
+  isInspectionCompliant = false,
+): InspectionCompleteParams {
+  return {
+    startTasks: jest.fn(() => Promise.resolve()),
+    sightState: {
+      isInspectionCompliant,
+      isInspectionCompleted: false,
+      setIsInspectionCompleted: jest.fn(),
+    } as unknown as PhotoCaptureSightState,
+    loading: {
+      start: jest.fn(),
+      onSuccess: jest.fn(),
+      onError: jest.fn(),
+    } as unknown as LoadingState,
+    startTasksOnComplete: true,
+    onUpdateDuration: jest.fn(() => Promise.resolve(1234)),
+    cleanupImages: jest.fn(() => imagesCleanupPromise),
+  };
+}
+
+describe('useInspectionComplete hook', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not start the inspection tasks before the images cleanup is completed', async () => {
+    const imagesCleanupPromise = createFakePromise<void>();
+    const initialProps = createParams(imagesCleanupPromise);
+    const { result, unmount } = renderHook(useInspectionComplete, { initialProps });
+
+    result.current.handleInspectionCompleted();
+    await flushPromises();
+    expect(initialProps.cleanupImages).toHaveBeenCalled();
+    expect(initialProps.loading.start).toHaveBeenCalled();
+    expect(initialProps.startTasks).not.toHaveBeenCalled();
+
+    imagesCleanupPromise.resolve();
+    await flushPromises();
+    expect(initialProps.startTasks).toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('should wait for the images cleanup when the inspection is automatically completed', async () => {
+    const imagesCleanupPromise = createFakePromise<void>();
+    const initialProps = createParams(imagesCleanupPromise, true);
+    const { unmount } = renderHook(useInspectionComplete, { initialProps });
+
+    await flushPromises();
+    expect(initialProps.cleanupImages).toHaveBeenCalled();
+    expect(initialProps.startTasks).not.toHaveBeenCalled();
+
+    imagesCleanupPromise.resolve();
+    await flushPromises();
+    expect(initialProps.startTasks).toHaveBeenCalled();
+
+    unmount();
+  });
+});


### PR DESCRIPTION
## Overview
<!-- Replace XXX with the ticket number in both the text and the link below -->
<!-- Or remove the line if there are no corresponding ticket -->
Jira Ticket Reference : [MN-904](https://acvauctions.atlassian.net/browse/MN-904)

<!-- Provide a small description of this PR and the feature it implements -->
`useInspectionComplete` hook consumes `cleanupImages` fn to prevent race condition between starting tasks and deleting an image.

## Checklist before requesting a review
<!-- Make sure that all the items below are checked before requesting a review -->

- [x] I have updated the unit tests based on the changes I made
- [x] I have updated the docs (TSDoc / README / global doc) to reflect my changes
- [x] I have updated the local app configs if needed
- [x] I have performed self-QA of my feature by testing the apps and packages and made sure that :
  - No regression or new bug has occurred
  - The acceptance criteria listed in the ticket are met
  - **Self-QA was made on both desktop and mobile**


[MN-904]: https://acvauctions.atlassian.net/browse/MN-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ