### PR TITLE
Escaped duplicate sight names and / character in download all images

### DIFF
--- a/packages/inspection-review/src/components/DownloadImagesButton/hooks/useDownloadImages.ts
+++ b/packages/inspection-review/src/components/DownloadImagesButton/hooks/useDownloadImages.ts
@@ -6,7 +6,10 @@ import { DownloadImagesButtonProps } from '../../../types/download-images.types'
 import { useInspectionReviewProvider } from '../../../hooks';
 
 function transformToKebabCase(input: string): string {
-  return input.replace(/\s+/g, '-').toLowerCase();
+  return input
+    .replace(/[\\/:*?"<>|]+/g, '-')
+    .replace(/\s+/g, '-')
+    .toLowerCase();
 }
 
 /**
@@ -47,8 +50,13 @@ export function useDownloadImages(props: DownloadImagesButtonProps): DownloadIma
     const res = await Promise.all(promises);
     const zip = new JSZip();
 
+    const usedFileNameCounts = new Map<string, number>();
     res.forEach(({ blob, label }, index) => {
-      zip.file(`${label ? transformToKebabCase(label) : index}.jpg`, blob);
+      const baseName = label ? transformToKebabCase(label) : `${index}`;
+      const occurrence = usedFileNameCounts.get(baseName) ?? 0;
+      usedFileNameCounts.set(baseName, occurrence + 1);
+      const fileName = occurrence === 0 ? baseName : `${baseName}-${occurrence}`;
+      zip.file(`${fileName}.jpg`, blob);
     });
 
     const zipFile = await zip.generateAsync({ type: 'blob' });

--- a/packages/inspection-review/test/components/DownloadImagesButton/hooks/useDownloadImages.test.ts
+++ b/packages/inspection-review/test/components/DownloadImagesButton/hooks/useDownloadImages.test.ts
@@ -487,5 +487,148 @@ describe('useDownloadImages', () => {
         expect(mockZipInstance.file).toHaveBeenCalledWith('uppercase-label.jpg', expect.any(Blob));
       });
     });
+
+    it('should escape forward slashes so labels cannot create subdirectories', async () => {
+      mockUseInspectionReviewProvider.mockReturnValue({
+        allGalleryItems: [
+          createMockGalleryItem({
+            image: {
+              id: 'image-1',
+              path: MOCK_IMAGE_PATH_1,
+              label: { [MOCK_LANGUAGE]: 'Rear Wheel/Tire' },
+            } as Image,
+          }),
+        ],
+        inspection: { id: MOCK_INSPECTION_ID } as Inspection,
+        additionalInfo: undefined,
+      } as unknown as InspectionReviewProviderState);
+
+      const props = createMockProps();
+      const { result } = renderHook(() => useDownloadImages(props));
+
+      act(() => {
+        result.current.handleDownloadImages();
+      });
+
+      await waitFor(() => {
+        expect(mockZipInstance.file).toHaveBeenCalledWith('rear-wheel-tire.jpg', expect.any(Blob));
+        expect(mockZipInstance.file).not.toHaveBeenCalledWith(
+          expect.stringContaining('/'),
+          expect.any(Blob),
+        );
+      });
+    });
+
+    it('should escape other filesystem-unsafe characters (backslash, colon, etc.)', async () => {
+      mockUseInspectionReviewProvider.mockReturnValue({
+        allGalleryItems: [
+          createMockGalleryItem({
+            image: {
+              id: 'image-1',
+              path: MOCK_IMAGE_PATH_1,
+              label: { [MOCK_LANGUAGE]: 'Front:Left\\Panel?Bumper' },
+            } as Image,
+          }),
+        ],
+        inspection: { id: MOCK_INSPECTION_ID } as Inspection,
+        additionalInfo: undefined,
+      } as unknown as InspectionReviewProviderState);
+
+      const props = createMockProps();
+      const { result } = renderHook(() => useDownloadImages(props));
+
+      act(() => {
+        result.current.handleDownloadImages();
+      });
+
+      await waitFor(() => {
+        expect(mockZipInstance.file).toHaveBeenCalledWith(
+          'front-left-panel-bumper.jpg',
+          expect.any(Blob),
+        );
+      });
+    });
+  });
+
+  describe('duplicate filename handling', () => {
+    it('should not overwrite images that share the same label', async () => {
+      mockUseInspectionReviewProvider.mockReturnValue({
+        allGalleryItems: [
+          createMockGalleryItem({
+            image: {
+              id: 'image-1',
+              path: MOCK_IMAGE_PATH_1,
+              label: { [MOCK_LANGUAGE]: 'Front View' },
+            } as Image,
+          }),
+          createMockGalleryItem({
+            image: {
+              id: 'image-2',
+              path: MOCK_IMAGE_PATH_2,
+              label: { [MOCK_LANGUAGE]: 'Front View' },
+            } as Image,
+          }),
+        ],
+        inspection: { id: MOCK_INSPECTION_ID } as Inspection,
+        additionalInfo: undefined,
+      } as unknown as InspectionReviewProviderState);
+
+      const props = createMockProps();
+      const { result } = renderHook(() => useDownloadImages(props));
+
+      act(() => {
+        result.current.handleDownloadImages();
+      });
+
+      await waitFor(() => {
+        expect(mockZipInstance.file).toHaveBeenCalledWith('front-view.jpg', expect.any(Blob));
+        expect(mockZipInstance.file).toHaveBeenCalledWith('front-view-1.jpg', expect.any(Blob));
+        expect(mockZipInstance.file).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('should increment the suffix for each additional occurrence of the same label', async () => {
+      mockUseInspectionReviewProvider.mockReturnValue({
+        allGalleryItems: [
+          createMockGalleryItem({
+            image: {
+              id: 'image-1',
+              path: MOCK_IMAGE_PATH_1,
+              label: { [MOCK_LANGUAGE]: 'Front View' },
+            } as Image,
+          }),
+          createMockGalleryItem({
+            image: {
+              id: 'image-2',
+              path: MOCK_IMAGE_PATH_2,
+              label: { [MOCK_LANGUAGE]: 'Front View' },
+            } as Image,
+          }),
+          createMockGalleryItem({
+            image: {
+              id: 'image-3',
+              path: MOCK_IMAGE_PATH_1,
+              label: { [MOCK_LANGUAGE]: 'Front View' },
+            } as Image,
+          }),
+        ],
+        inspection: { id: MOCK_INSPECTION_ID } as Inspection,
+        additionalInfo: undefined,
+      } as unknown as InspectionReviewProviderState);
+
+      const props = createMockProps();
+      const { result } = renderHook(() => useDownloadImages(props));
+
+      act(() => {
+        result.current.handleDownloadImages();
+      });
+
+      await waitFor(() => {
+        expect(mockZipInstance.file).toHaveBeenCalledWith('front-view.jpg', expect.any(Blob));
+        expect(mockZipInstance.file).toHaveBeenCalledWith('front-view-1.jpg', expect.any(Blob));
+        expect(mockZipInstance.file).toHaveBeenCalledWith('front-view-2.jpg', expect.any(Blob));
+        expect(mockZipInstance.file).toHaveBeenCalledTimes(3);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Overview
<!-- Replace XXX with the ticket number in both the text and the link below -->
<!-- Or remove the line if there are no corresponding ticket -->
Jira Ticket Reference : [MN-905](https://acvauctions.atlassian.net/browse/MN-905)

<!-- Provide a small description of this PR and the feature it implements -->
Escaped duplicate sight names and / character when downloading all images.

## Checklist before requesting a review
<!-- Make sure that all the items below are checked before requesting a review -->

- [x] I have updated the unit tests based on the changes I made
- [x] I have updated the docs (TSDoc / README / global doc) to reflect my changes
- [x] I have updated the local app configs if needed
- [x] I have performed self-QA of my feature by testing the apps and packages and made sure that :
  - No regression or new bug has occurred
  - The acceptance criteria listed in the ticket are met
  - **Self-QA was made on both desktop and mobile**


[MN-905]: https://acvauctions.atlassian.net/browse/MN-905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ