### PR TITLE
fix(network): defer optimistic dispatch in addImage to prevent React insertBefore crash

### DIFF
--- a/packages/network/src/api/image/requests.ts
+++ b/packages/network/src/api/image/requests.ts
@@ -610,6 +610,13 @@ export async function addImage(
   dispatch?: Dispatch<MonkCreatedOneImageAction>,
 ): Promise<MonkApiResponse<AddImageResponse, ApiImage>> {
   const localImage = createLocalImage(options);
+  // Defer the optimistic dispatch by one microtask to avoid firing a synchronous React state
+  // update inside an already-running async queue callback (useQueue.processItem calls
+  // setProcessedItems and then immediately awaits process(item)). Without this deferral, two
+  // concurrent setState calls collide in React 17's legacy synchronous reconciler and cause a
+  // torn render that crashes with "NotFoundError: Failed to execute 'insertBefore' on 'Node'".
+  // See: https://sentry.io/organizations/monkai/issues/DRIVE-APP-Q/
+  await Promise.resolve();
   dispatch?.({
     type: MonkActionType.CREATED_ONE_IMAGE,
     payload: {


### PR DESCRIPTION
## Problem

**Sentry issue:** [DRIVE-APP-Q](https://monkai.sentry.io/issues/DRIVE-APP-Q/) — 800+ events, Android / NL production users.

`NotFoundError: Failed to execute 'insertBefore' on 'Node'` crash in React DOM, triggered during image upload in the drive-app.

## Root Cause

Inside `addImage()`, a synchronous `dispatch()` call fires an optimistic Redux state update (`CREATED_ONE_IMAGE`) **before** the first `await`. This collides with a `setProcessedItems()` call already in flight from `useQueue.processItem()`, causing two concurrent React 17 state updates that tear the render and crash the DOM reconciler.

```
useQueue.processItem()
  → setProcessedItems([...items, item])   ← setState #1
  → await process(item)
       → addImage()
           → dispatch(CREATED_ONE_IMAGE)  ← setState #2 (synchronous, before any await)
                                          ← React 17 reconciler collision → insertBefore crash ❌
```

## Fix

Add `await Promise.resolve()` before the optimistic dispatch in `addImage()`. This yields to the event loop for one microtask, allowing React to finish flushing the `setProcessedItems` render before the second state update is applied — eliminating the collision entirely.

```diff
+ await Promise.resolve();
  dispatch?.({
    type: MonkActionType.CREATED_ONE_IMAGE,
    payload: { inspectionId: options.inspectionId, image: localImage },
  });
```

## Investigation notes

Full bug report and root cause analysis: https://www.notion.so/monkvision/Bug-Report-drive-app-React-insertBefore-Crash-DRIVE-APP-Q-3c930e73786e81eea9e2cfaff0b2f31d

## Checklist

- [x] Single-line, surgical fix — no logic changes
- [x] No observable UX change (microtask deferral is imperceptible)
- [x] Applies to all `ImageUploadType` variants (beauty shot, close-up, video frame, etc.)
